### PR TITLE
Add button to set min ETH balance

### DIFF
--- a/src/components/account/wallet_weth_balance.tsx
+++ b/src/components/account/wallet_weth_balance.tsx
@@ -88,6 +88,7 @@ const modalStyle = {
         bottom: 'auto',
         marginRight: '-50%',
         transform: 'translate(-50%, -50%)',
+        minWidth: '400px',
     },
 };
 
@@ -127,7 +128,6 @@ class WalletWethBalance extends React.PureComponent<Props, State> {
                         <Value>{formattedTotalEth} ETH</Value>
                     </Row>
                     <WethModal
-                        ethBalance={ethBalance}
                         wethBalance={wethBalance}
                         totalEth={totalEth}
                         isOpen={this.state.modalIsOpen}

--- a/src/components/account/wallet_weth_modal.tsx
+++ b/src/components/account/wallet_weth_modal.tsx
@@ -1,11 +1,12 @@
 import { BigNumber } from '0x.js';
 import React from 'react';
 import Modal from 'react-modal';
+import styled from 'styled-components';
 
 import { tokenAmountInUnits, unitsInTokenAmount } from '../../util/tokens';
+import { Button as ButtonBase } from '../common/button';
 
 interface Props extends React.ComponentProps<typeof Modal> {
-    ethBalance: BigNumber;
     wethBalance: BigNumber;
     totalEth: BigNumber;
     isSubmitting: boolean;
@@ -16,38 +17,124 @@ interface State {
     selectedWeth: BigNumber;
 }
 
+const Slider = styled.input`
+    -webkit-appearance: none;
+    margin: 1em 0;
+    cursor: pointer;
+    width: 100%;
+
+    &:focus {
+        outline: none;
+    }
+
+    &::-webkit-slider-runnable-track {
+        height: 0.25em;
+
+        box-shadow: 1px 1px 1px #000000, 0px 0px 1px #0d0d0d;
+        background: #3071a9;
+        border-radius: 1.3px;
+        border: 0.2px solid #010101;
+    }
+
+    &::-webkit-slider-thumb {
+        -webkit-appearance: none;
+        box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.25);
+        border: 0.5px solid rgba(0, 0, 0, 0.142);
+        height: 1em;
+        width: 1em;
+        border-radius: 1em;
+        background: white;
+        cursor: pointer;
+        margin-top: -0.4em;
+    }
+`;
+
+const Button = styled(ButtonBase)`
+    width: 100%;
+    font-weight: bold;
+`;
+
+const CloseButton = styled.span`
+    float: right;
+    cursor: pointer;
+`;
+
+const Title = styled.h1`
+    clear: both;
+    font-size: 20px;
+    text-align: center;
+`;
+
+const SetMinEthWrapper = styled.div`
+    margin-bottom: 1rem;
+`;
+
+const SetMinEthButton = styled.a`
+    display: inline-block;
+    color: black;
+    text-decoration: none;
+    border-bottom: 1px dotted black;
+`;
+
+const EthBox = styled.div`
+    display: inline-block;
+    text-align: center;
+    border: 1px solid #dedede;
+    padding: 28px 40px;
+`;
+const WethBox = styled(EthBox)`
+    float: right;
+`;
+
+const EthBoxValue = styled.div`
+    font-size: 24px;
+    color: #666666;
+`;
+const EthBoxUnit = styled.div``;
+
+const minEth = unitsInTokenAmount('0.5', 18);
+
 class WethModal extends React.Component<Props, State> {
     public state = {
         selectedWeth: this.props.wethBalance,
     };
 
     public render = () => {
-        const { onSubmit, isSubmitting, totalEth, ethBalance, wethBalance, ...restProps } = this.props;
+        const { onSubmit, isSubmitting, totalEth, wethBalance, ...restProps } = this.props;
 
-        const maxEth = totalEth.mul(1.05);
+        const selectedEth = totalEth.sub(this.state.selectedWeth);
 
         const initialWethStr = tokenAmountInUnits(this.props.wethBalance, 18);
-        const maxEthStr = tokenAmountInUnits(maxEth, 18);
         const selectedWethStr = tokenAmountInUnits(this.state.selectedWeth, 18);
+        const selectedEthStr = tokenAmountInUnits(selectedEth, 18);
+        const totalEthStr = tokenAmountInUnits(totalEth, 18);
 
-        const ethBalanceStr = tokenAmountInUnits(this.props.ethBalance, 18);
-        const wethBalanceStr = tokenAmountInUnits(this.props.wethBalance, 18);
+        const isInsufficientEth = selectedEth.lessThan(minEth);
 
-        const isDisabled = selectedWethStr === initialWethStr || isSubmitting;
+        const isDisabled = selectedWethStr === initialWethStr || isSubmitting || isInsufficientEth;
 
         return (
             <Modal {...restProps}>
-                <span onClick={this.closeModal} style={{float: 'right'}}>X</span>
-                <div>{ethBalanceStr} ETH</div>
-                <div>{wethBalanceStr} wETH</div>
-                <div>Selected: {selectedWethStr}</div>
+                <CloseButton onClick={this.closeModal}>X</CloseButton>
+                <Title>Available Balance</Title>
+                <EthBox>
+                    <EthBoxValue>{selectedEthStr}</EthBoxValue>
+                    <EthBoxUnit>ETH</EthBoxUnit>
+                </EthBox>
+                <WethBox>
+                    <EthBoxValue>{selectedWethStr}</EthBoxValue>
+                    <EthBoxUnit>wETH</EthBoxUnit>
+                </WethBox>
                 <div>
-                    <label>
-                        Select wETH
-                        <input type="range" min="0" max={maxEthStr} step="0.1" value={selectedWethStr} onChange={this.updateSelectedWeth}/>
-                    </label>
+                    <Slider type="range" min="0" max={totalEthStr} step="0.01" value={selectedWethStr} onChange={this.updateSelectedWeth} />
                 </div>
-                <button onClick={this.submit} disabled={isDisabled}>Update Balance{isSubmitting && '...'}</button>
+                {isInsufficientEth ? (
+                    <SetMinEthWrapper>
+                        ETH required for fees.&nbsp;
+                        <SetMinEthButton href="" onClick={this.setMinEth}>0.5 ETH Recommended</SetMinEthButton>
+                    </SetMinEthWrapper>
+                ) : <SetMinEthWrapper>&nbsp;</SetMinEthWrapper> }
+                <Button onClick={this.submit} disabled={isDisabled}>Update Balance{isSubmitting && '...'}</Button>
             </Modal>
         );
     }
@@ -57,13 +144,7 @@ class WethModal extends React.Component<Props, State> {
     }
 
     public updateSelectedWeth: React.ReactEventHandler<HTMLInputElement> = e => {
-        const { totalEth } = this.props;
-
-        let newSelectedWeth = unitsInTokenAmount(e.currentTarget.value, 18);
-        const totalEthMinusFee = totalEth.sub(unitsInTokenAmount('0.5', 18));
-        if (newSelectedWeth.greaterThan(totalEthMinusFee)) {
-            newSelectedWeth = totalEthMinusFee;
-        }
+        const newSelectedWeth = unitsInTokenAmount(e.currentTarget.value, 18);
 
         this.setState({
             selectedWeth: newSelectedWeth,
@@ -74,6 +155,14 @@ class WethModal extends React.Component<Props, State> {
         if (this.props.onRequestClose) {
             this.props.onRequestClose(e);
         }
+    }
+
+    public setMinEth: React.ReactEventHandler<HTMLAnchorElement> = e => {
+        e.preventDefault();
+
+        this.setState({
+            selectedWeth: this.props.totalEth.sub(minEth),
+        });
     }
 }
 

--- a/src/components/common/button.tsx
+++ b/src/components/common/button.tsx
@@ -1,0 +1,33 @@
+import React, { HTMLAttributes } from 'react';
+import styled from 'styled-components';
+
+interface Props extends HTMLAttributes<HTMLButtonElement> {
+    children: React.ReactNode;
+    disabled: boolean;
+}
+
+const StyledButton = styled.button`
+    background-color: #002979;
+    color: white;
+    border: 0;
+    border-radius: 4px;
+    padding: 0.5em;
+
+    &:focus {
+        outline: none;
+    }
+
+    &:disabled {
+        background-color: #b2bfd7;
+    }
+`;
+
+export const Button: React.FC<Props> = props => {
+    const { children, ...restProps } = props;
+
+    return (
+        <StyledButton {...restProps}>
+            {children}
+        </StyledButton>
+    );
+};


### PR DESCRIPTION
The modal for wrapping/unwrapping wETH was forbidding the user to select an amount that would leave them with less than 0.5 ETH, but that's not what the design shows. Instead, the user can select any value, but if the ETH value selected is less than 0.5, the button will be disabled and a message will be shown. This message can be clicked to set the selected wETH to a value that still leaves 0.5 ETH in the account balance.

This PR also adds some basic styling to the modal.