### PR TITLE
Allow editing fields in eth wrapper modal

### DIFF
--- a/src/components/account/wallet_weth_balance.tsx
+++ b/src/components/account/wallet_weth_balance.tsx
@@ -152,7 +152,7 @@ class WalletWethBalance extends React.PureComponent<Props, State> {
             content = (
                 <>
                     <Row>
-                        <Label>wETH</Label>
+                        <Label>ETH</Label>
                         <Value>{formattedEth}</Value>
                     </Row>
                     <Button onClick={this.openModal}>
@@ -161,7 +161,7 @@ class WalletWethBalance extends React.PureComponent<Props, State> {
                     </Button>
                     <Row>
                         <LabelWrapper>
-                            <Label>ETH</Label> <Tooltip type="full" />
+                            <Label>wETH</Label> <Tooltip type="full" />
                         </LabelWrapper>
                         <Value>{formattedWeth}</Value>
                     </Row>

--- a/src/components/common/big_number_input.test.tsx
+++ b/src/components/common/big_number_input.test.tsx
@@ -1,0 +1,101 @@
+import { BigNumber } from '0x.js';
+import { mount } from 'enzyme';
+import React from 'react';
+
+import { BigNumberInput } from './big_number_input';
+
+const noop = () => ({});
+
+describe('BigNumberInput', () => {
+    it('should be initialized with value', () => {
+        // given
+        const value = new BigNumber('123');
+
+        // when
+        const wrapper = mount(<BigNumberInput value={value} decimals={2} onChange={noop} />);
+
+        // then
+        expect(wrapper.find('input').props().value).toEqual('1.23');
+    });
+
+    it('should trigger the onChange callback with the proper value', () => {
+        // given
+        const value = new BigNumber('123');
+        const onChange = jest.fn();
+
+        // when
+        const wrapper = mount(<BigNumberInput value={value} decimals={2} onChange={onChange} />);
+        changeValue(wrapper, '2.45');
+
+        // then
+        expect(onChange).toHaveBeenCalledTimes(1);
+        expect(onChange).toHaveBeenCalledWith(new BigNumber('245'));
+    });
+
+    it('should change when value changes', () => {
+        // given
+        const value = new BigNumber('123');
+        const onChange = jest.fn();
+
+        // when
+        const wrapper = mount(<BigNumberInput value={value} decimals={2} onChange={onChange} />);
+
+        // then
+        expect(wrapper.find('input').props().value).toEqual('1.23');
+
+        // when
+        wrapper.setProps({ value: new BigNumber('245') });
+
+        // then
+        expect(wrapper.find('input').props().value).toEqual('2.45');
+    });
+
+    it('should allow entering an empty string', () => {
+        // given
+        const value = new BigNumber('123');
+        const onChange = jest.fn();
+        // when
+
+        const wrapper = mount(<BigNumberInput value={value} decimals={2} onChange={onChange} />);
+        changeValue(wrapper, '');
+
+        // then
+        expect(onChange).toHaveBeenCalledTimes(1);
+        expect(onChange).toHaveBeenCalledWith(new BigNumber('0'));
+    });
+
+    it('should accept a min value', () => {
+        // given
+        const value = new BigNumber('123');
+        const onChange = jest.fn();
+        const minValue = new BigNumber('100');
+
+        // when
+        const wrapper = mount(<BigNumberInput min={minValue} value={value} decimals={2} onChange={onChange} />);
+        changeValue(wrapper, '0.5');
+
+        // then
+        expect(wrapper.find('input').props().value).toEqual('1.23');
+        expect(onChange).toHaveBeenCalledTimes(0);
+    });
+
+    it('should accept a max value', () => {
+        // given
+        const value = new BigNumber('123');
+        const onChange = jest.fn();
+        const maxValue = new BigNumber('200');
+
+        // when
+        const wrapper = mount(<BigNumberInput max={maxValue} value={value} decimals={2} onChange={onChange} />);
+        changeValue(wrapper, '3.5');
+
+        // then
+        expect(wrapper.find('input').props().value).toEqual('1.23');
+        expect(onChange).toHaveBeenCalledTimes(0);
+    });
+});
+
+function changeValue(wrapper: any, value: string): void {
+    (wrapper.find('input').instance() as any).value = value;
+    wrapper.find('input').simulate('change');
+}

--- a/src/components/common/big_number_input.tsx
+++ b/src/components/common/big_number_input.tsx
@@ -1,0 +1,73 @@
+import { BigNumber } from '0x.js';
+import React from 'react';
+
+import { tokenAmountInUnits, unitsInTokenAmount } from '../../util/tokens';
+
+interface Props {
+    value: BigNumber;
+    decimals: number;
+    onChange: (newValue: BigNumber) => void;
+    min?: BigNumber;
+    max?: BigNumber;
+    step?: BigNumber;
+}
+
+interface State {
+    currentValueStr: string;
+}
+
+export class BigNumberInput extends React.Component<Props, State> {
+    public readonly state = {
+        currentValueStr: tokenAmountInUnits(this.props.value, this.props.decimals),
+    };
+
+    public static getDerivedStateFromProps = (props: Props, state: State) => {
+        const { decimals, value } = props;
+        const { currentValueStr } = state;
+
+        if (!unitsInTokenAmount(currentValueStr || '0', decimals).eq(value)) {
+            return {
+                currentValueStr: tokenAmountInUnits(value, decimals),
+            };
+        } else {
+            return null;
+        }
+    };
+
+    public render = () => {
+        const { currentValueStr } = this.state;
+        const { decimals, step, min, max } = this.props;
+
+        const stepStr = step && tokenAmountInUnits(step, decimals);
+        const minStr = min && tokenAmountInUnits(min, decimals);
+        const maxStr = max && tokenAmountInUnits(max, decimals);
+
+        return (
+            <input
+                type="number"
+                value={currentValueStr}
+                onChange={this._updateValue}
+                step={stepStr}
+                min={minStr}
+                max={maxStr}
+            />
+        );
+    };
+
+    private readonly _updateValue: React.ReactEventHandler<HTMLInputElement> = e => {
+        const { decimals, onChange, min, max } = this.props;
+        const newValueStr = e.currentTarget.value;
+
+        const newValue = unitsInTokenAmount(newValueStr || '0', decimals);
+        const invalidValue = (min && newValue.lessThan(min)) || (max && newValue.greaterThan(max));
+        if (invalidValue) {
+            return;
+        }
+
+        onChange(newValue);
+
+        this.setState({
+            currentValueStr: newValueStr,
+        });
+    };
+}


### PR DESCRIPTION
Closes #37.

Clicking a value in the eth wrapper modal makes an input appear that allows to enter the new value.