### PR TITLE
Use maker account as senderAddress

### DIFF
--- a/src/util/orders.test.ts
+++ b/src/util/orders.test.ts
@@ -12,7 +12,7 @@ describe('buildOrder', () => {
         const wethAddress = '0x0000000000000000000000000000000000000003';
         const exchangeAddress = '0x0000000000000000000000000000000000000004';
         const amount = new BigNumber('100');
-        const price = 0.1;
+        const price = new BigNumber('0.1');
 
         // when
         const order = buildOrder(
@@ -39,6 +39,7 @@ describe('buildOrder', () => {
         expect(order.takerAssetData).toEqual(
             '0xf47261b00000000000000000000000000000000000000000000000000000000000000002',
         );
+        expect(order.senderAddress).toEqual(account);
     });
 
     it('should build a sell order', async () => {
@@ -48,7 +49,7 @@ describe('buildOrder', () => {
         const wethAddress = '0x0000000000000000000000000000000000000003';
         const exchangeAddress = '0x0000000000000000000000000000000000000004';
         const amount = new BigNumber('100');
-        const price = 0.1;
+        const price = new BigNumber('0.1');
 
         // when
         const order = buildOrder(
@@ -75,5 +76,6 @@ describe('buildOrder', () => {
         expect(order.takerAssetData).toEqual(
             '0xf47261b00000000000000000000000000000000000000000000000000000000000000003',
         );
+        expect(order.senderAddress).toEqual(account);
     });
 });

--- a/src/util/orders.ts
+++ b/src/util/orders.ts
@@ -32,6 +32,6 @@ export const buildOrder = (params: BuildOrderParams, side: OrderSide): Order => 
         makerFee: new BigNumber(MAKER_FEE),
         takerFee: new BigNumber(TAKER_FEE),
         salt: generatePseudoRandomSalt(),
-        senderAddress: '0x0000000000000000000000000000000000000000',
+        senderAddress: account,
     };
 };


### PR DESCRIPTION
The [spec](https://github.com/0xProject/0x-protocol-specification/blob/master/v2/v2-specification.md#contract-interactions) says that the sender address is:

> Address that is allowed to call Exchange contract methods that affect this order. If set to 0, any address is allowed to call these methods.

We are setting it to 0 right now, which of course is not a good idea (it would mean, among other things, that anyone can cancel the order).

This PR uses the maker of the order as the sender address.