### PR TITLE
(Feature) Static notifications dropdown

### DIFF
--- a/src/components/account/notifications_dropdown.tsx
+++ b/src/components/account/notifications_dropdown.tsx
@@ -1,5 +1,5 @@
 import React, { HTMLAttributes } from 'react';
-import styled from 'styled-components';
+import styled, { keyframes } from 'styled-components';
 
 import { themeColors, themeDimensions } from '../../util/theme';
 import { CardBase } from '../common/card_base';
@@ -65,6 +65,20 @@ const NotificationItem = styled.div<{ active?: boolean }>`
 const NotificationContent = styled.div`
     flex-grow: 1;
     padding-right: 25px;
+`;
+
+const rotate = keyframes`
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
+`;
+
+const NotificationIconSpin = styled.div`
+    animation: ${rotate} 1.5s linear infinite;
 `;
 
 const NotificationIcon = styled.div`
@@ -207,7 +221,11 @@ class NotificationsDropdown extends React.Component<Props, State> {
             return <NotificationCheckmarkIcon />;
         }
 
-        return <NotificationProcessingIcon />;
+        return (
+            <NotificationIconSpin>
+                <NotificationProcessingIcon />
+            </NotificationIconSpin>
+        );
     };
 
     private readonly _loadNotifications = () => {

--- a/src/components/account/notifications_dropdown.tsx
+++ b/src/components/account/notifications_dropdown.tsx
@@ -209,6 +209,7 @@ class NotificationsDropdown extends React.Component<Props, State> {
                 header={header}
                 horizontalPosition={DropdownPositions.Right}
                 onClick={this._loadNotifications}
+                shouldCloseDropdownBodyOnClick={false}
                 {...restProps}
             />
         );

--- a/src/components/account/notifications_dropdown.tsx
+++ b/src/components/account/notifications_dropdown.tsx
@@ -14,6 +14,7 @@ interface Props extends HTMLAttributes<HTMLDivElement> {}
 
 interface State {
     isLoadingNotifications: boolean;
+    newNotifications: boolean;
 }
 
 enum NotificationsStatus {
@@ -27,6 +28,17 @@ const NotificationsDropdownWrapper = styled(Dropdown)``;
 const NotificationsDropdownHeader = styled.div`
     align-items: center;
     display: flex;
+    position: relative;
+`;
+
+const NewNotificationsBadge = styled.div`
+    background: #ff6534;
+    border-radius: 50%;
+    height: 7px;
+    position: absolute;
+    right: -4px;
+    top: 12px;
+    width: 7px;
 `;
 
 const NotificationsDropdownBody = styled(CardBase)`
@@ -45,10 +57,6 @@ const NotificationItem = styled.div<{ active?: boolean }>`
     justify-content: space-between;
     padding: 20px ${themeDimensions.horizontalPadding};
 
-    &:hover {
-        background-color: ${themeColors.rowActive};
-    }
-
     &:last-child {
         border-bottom: none;
     }
@@ -56,6 +64,11 @@ const NotificationItem = styled.div<{ active?: boolean }>`
 
 const NotificationContent = styled.div`
     flex-grow: 1;
+    padding-right: 25px;
+`;
+
+const NotificationIcon = styled.div`
+    flex-shrink: 0;
 `;
 
 const NotificationDropdownTitle = styled.h1`
@@ -144,6 +157,7 @@ const NOTIFICATIONS_LIST = [
 class NotificationsDropdown extends React.Component<Props, State> {
     public readonly state: State = {
         isLoadingNotifications: true,
+        newNotifications: true,
     };
 
     public render = () => {
@@ -155,13 +169,14 @@ class NotificationsDropdown extends React.Component<Props, State> {
                     <NotificationTitle>{item.title}</NotificationTitle>
                     <NotificationText>{item.text}</NotificationText>
                 </NotificationContent>
-                {this._getNotificationIcon(item.status)}
+                <NotificationIcon>{this._getNotificationIcon(item.status)}</NotificationIcon>
             </NotificationItem>
         ));
 
         const header = (
             <NotificationsDropdownHeader>
                 <BellIcon />
+                {this.state.newNotifications ? <NewNotificationsBadge /> : null}
             </NotificationsDropdownHeader>
         );
 
@@ -196,10 +211,12 @@ class NotificationsDropdown extends React.Component<Props, State> {
     };
 
     private readonly _loadNotifications = () => {
+        this.setState({ newNotifications: false });
+
         // This is only for showing the 'loading' component, delete ASAP
         setTimeout(() => {
             this.setState({ isLoadingNotifications: false });
-        }, 0);
+        }, 1000);
     };
 }
 

--- a/src/components/account/notifications_dropdown.tsx
+++ b/src/components/account/notifications_dropdown.tsx
@@ -1,0 +1,206 @@
+import React, { HTMLAttributes } from 'react';
+import styled from 'styled-components';
+
+import { themeColors, themeDimensions } from '../../util/theme';
+import { CardBase } from '../common/card_base';
+import { Dropdown, DropdownPositions } from '../common/dropdown';
+import { BellIcon } from '../common/icons/bell_icon';
+import { NotificationCancelIcon } from '../common/icons/notification_cancel_icon';
+import { NotificationCheckmarkIcon } from '../common/icons/notification_checkmark_icon';
+import { NotificationProcessingIcon } from '../common/icons/notification_processing_icon';
+import { Loading } from '../common/loading';
+
+interface Props extends HTMLAttributes<HTMLDivElement> {}
+
+interface State {
+    isLoadingNotifications: boolean;
+}
+
+enum NotificationsStatus {
+    Processing,
+    Success,
+    Cancel,
+}
+
+const NotificationsDropdownWrapper = styled(Dropdown)``;
+
+const NotificationsDropdownHeader = styled.div`
+    align-items: center;
+    display: flex;
+`;
+
+const NotificationsDropdownBody = styled(CardBase)`
+    width: 400px;
+`;
+const NotificationsList = styled.div`
+    height: 420px;
+    overflow: auto;
+`;
+
+const NotificationItem = styled.div<{ active?: boolean }>`
+    align-items: center;
+    background-color: ${props => (props.active ? themeColors.rowActive : 'transparent')};
+    border-bottom: 1px solid ${themeColors.borderColor};
+    display: flex;
+    justify-content: space-between;
+    padding: 20px ${themeDimensions.horizontalPadding};
+
+    &:hover {
+        background-color: ${themeColors.rowActive};
+    }
+
+    &:last-child {
+        border-bottom: none;
+    }
+`;
+
+const NotificationContent = styled.div`
+    flex-grow: 1;
+`;
+
+const NotificationDropdownTitle = styled.h1`
+    border-bottom: 1px solid ${themeColors.borderColor};
+    color: #000;
+    font-size: 16px;
+    font-weight: 600;
+    line-height: 1.2;
+    margin: 0;
+    padding: 15px ${themeDimensions.horizontalPadding};
+`;
+
+const NotificationTitle = styled.h2`
+    color: #000;
+    font-size: 16px;
+    font-weight: 600;
+    line-height: 1.2;
+    margin: 0 0 8px;
+`;
+
+const NotificationText = styled.p`
+    color: ${themeColors.textLight};
+    font-size: 16px;
+    font-weight: 400;
+    line-height: 1.2;
+    margin: 0;
+`;
+
+const LoadingStyled = styled(Loading)`
+    left: 50%;
+    min-height: 0;
+    position: absolute;
+    top: 50%;
+    transform: translateX(-50%) translateY(-50%);
+`;
+
+const NOTIFICATIONS_LIST = [
+    {
+        status: NotificationsStatus.Processing,
+        text: '00:15  (Est. 45 seconds)',
+        time: 45000,
+        title: 'Limit Buy 200.5 ZRX',
+    },
+    {
+        status: NotificationsStatus.Cancel,
+        text: '9 days ago',
+        title: 'Cancelled Order 15.33 REP',
+    },
+    {
+        status: NotificationsStatus.Success,
+        text: '4 minutes ago',
+        title: 'Market Sell 12 wETH',
+    },
+    {
+        status: NotificationsStatus.Cancel,
+        text: '9 days ago',
+        title: 'Cancelled Order 15.33 REP',
+    },
+    {
+        status: NotificationsStatus.Success,
+        text: '4 minutes ago',
+        title: 'Market Sell 12 wETH',
+    },
+    {
+        status: NotificationsStatus.Cancel,
+        text: '9 days ago',
+        title: 'Cancelled Order 15.33 REP',
+    },
+    {
+        status: NotificationsStatus.Success,
+        text: '4 minutes ago',
+        title: 'Market Sell 12 wETH',
+    },
+    {
+        status: NotificationsStatus.Cancel,
+        text: '9 days ago',
+        title: 'Cancelled Order 15.33 REP',
+    },
+    {
+        status: NotificationsStatus.Success,
+        text: '4 minutes ago',
+        title: 'Market Sell 12 wETH',
+    },
+];
+
+class NotificationsDropdown extends React.Component<Props, State> {
+    public readonly state: State = {
+        isLoadingNotifications: true,
+    };
+
+    public render = () => {
+        const { ...restProps } = this.props;
+
+        const notificationsList = NOTIFICATIONS_LIST.map((item, index) => (
+            <NotificationItem key={index} active={item.status === NotificationsStatus.Processing}>
+                <NotificationContent>
+                    <NotificationTitle>{item.title}</NotificationTitle>
+                    <NotificationText>{item.text}</NotificationText>
+                </NotificationContent>
+                {this._getNotificationIcon(item.status)}
+            </NotificationItem>
+        ));
+
+        const header = (
+            <NotificationsDropdownHeader>
+                <BellIcon />
+            </NotificationsDropdownHeader>
+        );
+
+        const body = (
+            <NotificationsDropdownBody>
+                <NotificationDropdownTitle>Notifications</NotificationDropdownTitle>
+                <NotificationsList>
+                    {this.state.isLoadingNotifications ? <LoadingStyled /> : notificationsList}
+                </NotificationsList>
+            </NotificationsDropdownBody>
+        );
+
+        return (
+            <NotificationsDropdownWrapper
+                body={body}
+                header={header}
+                horizontalPosition={DropdownPositions.Right}
+                onClick={this._loadNotifications}
+                {...restProps}
+            />
+        );
+    };
+
+    private readonly _getNotificationIcon = (status: NotificationsStatus) => {
+        if (status === NotificationsStatus.Cancel) {
+            return <NotificationCancelIcon />;
+        } else if (status === NotificationsStatus.Success) {
+            return <NotificationCheckmarkIcon />;
+        }
+
+        return <NotificationProcessingIcon />;
+    };
+
+    private readonly _loadNotifications = () => {
+        // This is only for showing the 'loading' component, delete ASAP
+        setTimeout(() => {
+            this.setState({ isLoadingNotifications: false });
+        }, 0);
+    };
+}
+
+export { NotificationsDropdown };

--- a/src/components/common/icons/bell_icon.tsx
+++ b/src/components/common/icons/bell_icon.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export const BellIcon = () => {
+    return (
+        <svg width="16" height="20" viewBox="0 0 16 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path
+                d="M8 19.5C9.1 19.5 10 18.6 10 17.5H6C6 18.6 6.9 19.5 8 19.5ZM14 13.5V8.5C14 5.4 12.4 2.9 9.5 2.2V1.5C9.5 0.7 8.8 0 8 0C7.2 0 6.5 0.7 6.5 1.5V2.2C3.6 2.9 2 5.4 2 8.5V13.5L0 15.5V16.5H16V15.5L14 13.5Z"
+                fill="#474747"
+            />
+        </svg>
+    );
+};

--- a/src/components/common/icons/notification_cancel_icon.tsx
+++ b/src/components/common/icons/notification_cancel_icon.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+export const NotificationCancelIcon = () => {
+    return (
+        <svg width="26" height="26" viewBox="0 0 26 26" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="13" cy="13" r="12" stroke="#FF6534" strokeWidth="2" />
+            <path
+                d="M8.61523 17.6175L17.3845 8.38672"
+                stroke="#FF6534"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+            />
+            <path
+                d="M8.38446 8.61719L17.6152 17.3864"
+                stroke="#FF6534"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+            />
+        </svg>
+    );
+};

--- a/src/components/common/icons/notification_checkmark_icon.tsx
+++ b/src/components/common/icons/notification_checkmark_icon.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export const NotificationCheckmarkIcon = () => {
+    return (
+        <svg width="26" height="26" viewBox="0 0 26 26" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="13" cy="13" r="12" stroke="#3CB34F" strokeWidth="2" />
+            <path
+                d="M8.99951 13.5712L12.1594 16.7271L18.3788 9.55469"
+                stroke="#3CB34F"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+            />
+        </svg>
+    );
+};

--- a/src/components/common/icons/notification_processing_icon.tsx
+++ b/src/components/common/icons/notification_processing_icon.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export const NotificationProcessingIcon = () => {
+    return (
+        <svg width="26" height="26" viewBox="0 0 26 26" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="13" cy="13" r="12" stroke="#358BF1" strokeOpacity="0.2" strokeWidth="2" />
+            <path
+                d="M13 25C19.6274 25 25 19.6274 25 13C25 6.37258 19.6274 1 13 1"
+                stroke="#358BF1"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+            />
+        </svg>
+    );
+};

--- a/src/components/common/toolbar.tsx
+++ b/src/components/common/toolbar.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 
 import { themeColors, themeDimensions } from '../../util/theme';
 import { WalletConnectionStatusContainer } from '../account';
+import { NotificationsDropdown } from '../account/notifications_dropdown';
 
 import { Logo } from './logo';
 import { MarketsDropdown } from './markets_dropdown';
@@ -93,6 +94,7 @@ export const Toolbar = () => (
         <ToolbarEnd>
             <MyWalletLink to="/my-wallet">My Wallet</MyWalletLink>
             <WalletDropdown />
+            <NotificationsDropdown />
         </ToolbarEnd>
     </ToolbarWrapper>
 );


### PR DESCRIPTION
Closes #64 
Closes #61 

- Dropdown has no tip on top (the little triangle thing), because it's imposible to align it with the bell icon and keep the dropdown completely inside the screen.
- Little red circle for unread / new notifications appears on first load, it should disappear when you open the dropdown. Reload to make it appear again. 
- No progress bar for active items (for now, at least).
- Items are not clickable (this can be changed easily later).

![screen shot 2019-03-01 at 12 03 55](https://user-images.githubusercontent.com/4015436/53646856-00fee880-3c1b-11e9-893d-601d49ac707a.png)
