### PR TITLE
(add) tooltip component

### DIFF
--- a/src/components/account/wallet_weth_balance.tsx
+++ b/src/components/account/wallet_weth_balance.tsx
@@ -11,7 +11,7 @@ import { StoreState, Web3State } from '../../util/types';
 import { Card } from '../common/card';
 import { ArrowUpDownIcon } from '../common/icons/arrow_up_down_icon';
 import { CardLoading } from '../common/loading';
-import { Tooltip } from '../common/tooltip';
+import { IconType, Tooltip, TooltipPosition } from '../common/tooltip';
 
 import { WethModal } from './wallet_weth_modal';
 
@@ -161,7 +161,12 @@ class WalletWethBalance extends React.PureComponent<Props, State> {
                     </Button>
                     <Row>
                         <LabelWrapper>
-                            <Label>wETH</Label> <Tooltip type="full" />
+                            <Label>wETH</Label>{' '}
+                            <Tooltip
+                                description="Some text to show in this simple tooltip..."
+                                iconType={IconType.Fill}
+                                tooltipPosition={TooltipPosition.Bottom}
+                            />
                         </LabelWrapper>
                         <Value>{formattedWeth}</Value>
                     </Row>

--- a/src/components/account/wallet_weth_modal.tsx
+++ b/src/components/account/wallet_weth_modal.tsx
@@ -8,7 +8,7 @@ import { tokenAmountInUnits, unitsInTokenAmount } from '../../util/tokens';
 import { BigNumberInput } from '../common/big_number_input';
 import { Button as ButtonBase } from '../common/button';
 import { CloseModalButton } from '../common/icons/close_modal_button';
-import { Tooltip } from '../common/tooltip';
+import { Tooltip, TooltipPosition } from '../common/tooltip';
 
 enum Editing {
     Eth,
@@ -229,7 +229,10 @@ class WethModal extends React.Component<Props, State> {
                         )}
                         <EthBoxUnit>wETH</EthBoxUnit>
                         <TooltipStyled>
-                            <Tooltip />
+                            <Tooltip
+                                description="Some text to show in this simple tooltip..."
+                                tooltipPosition={TooltipPosition.Left}
+                            />
                         </TooltipStyled>
                     </EthBox>
                 </EthBoxes>

--- a/src/components/common/tooltip.tsx
+++ b/src/components/common/tooltip.tsx
@@ -1,19 +1,91 @@
 import React, { HTMLAttributes } from 'react';
-import styled from 'styled-components';
+import styled, { keyframes } from 'styled-components';
 
 import { InfoIcon } from './icons/info_icon';
 import { InfoIconFull } from './icons/info_icon_full';
 
-interface Props extends HTMLAttributes<HTMLDivElement> {
-    type?: string;
+export enum TooltipPosition {
+    Top = 1,
+    Bottom = 2,
+    Left = 3,
+    Right = 4,
 }
 
-const TooltipWrapper = styled.div`
+export enum IconType {
+    Line = 1,
+    Fill = 2,
+}
+
+interface Props extends HTMLAttributes<HTMLDivElement> {
+    description?: string;
+    iconType?: IconType;
+    tooltipPosition?: TooltipPosition;
+    tabIndex?: number;
+}
+
+const TooltipPopup = styled.div`
     cursor: pointer;
+    display: flex;
+    justify-content: center;
+    outline: none;
+    position: relative;
+
+    &:focus {
+        cursor: default;
+        > div {
+            display: block;
+        }
+    }
+`;
+
+const tooltipAnimation = keyframes`
+    0% {
+        opacity: 0;
+    }
+    100% {
+        opacity: 1;
+    }
+`;
+
+const TooltipContent = styled.div<{ position: TooltipPosition }>`
+    animation-fill-mode: forwards;
+    animation: ${tooltipAnimation} 0.15s linear 1;
+    background-color: rgba(0, 0, 0, 0.8);
+    border-radius: 4px;
+    border: none;
+    box-shadow: 0 1px 5px 0 rgba(0, 0, 0, 0.09);
+    color: #fff;
+    display: none;
+    font-size: 11px;
+    font-weight: 400;
+    line-height: 1.2;
+    min-width: 140px;
+    padding: 8px 10px;
+    position: absolute;
+
+    ${props => (props.position === TooltipPosition.Bottom ? 'top: 20px;' : '')}
+    ${props => (props.position === TooltipPosition.Top ? 'bottom: 20px;' : '')}
+    ${props =>
+        props.position === TooltipPosition.Right || props.position === TooltipPosition.Left
+            ? 'top: 50%; transform: translateY(-50%);'
+            : ''}
+    ${props => (props.position === TooltipPosition.Right ? 'left: 20px;' : '')}
+    ${props => (props.position === TooltipPosition.Left ? 'right: 20px;' : '')}
 `;
 
 export const Tooltip: React.FC<Props> = props => {
-    const { type = 'line' } = props;
+    const { iconType = IconType.Line, description, tooltipPosition, ...restProps } = props;
+    const tooltipContent = description ? (
+        <TooltipContent position={tooltipPosition ? tooltipPosition : TooltipPosition.Top}>
+            {props.description}
+        </TooltipContent>
+    ) : null;
+    const tooltipIcon = iconType === IconType.Fill ? <InfoIconFull /> : <InfoIcon />;
 
-    return <TooltipWrapper>{type === 'full' ? <InfoIconFull /> : <InfoIcon />}</TooltipWrapper>;
+    return (
+        <TooltipPopup tabIndex={-1} {...restProps}>
+            {tooltipIcon}
+            {tooltipContent}
+        </TooltipPopup>
+    );
 };


### PR DESCRIPTION
Closes #137 

There is no design for this.

Simple tooltip to show some text. More advances features would require to get some other component from NPM, I think.

There's no real content for the tooltips yet (maybe they shouldn't show if text is empty?).

It should look something like this:

![Screen Shot 2019-03-13 at 16 43 36](https://user-images.githubusercontent.com/4015436/54309970-13303d80-45b0-11e9-85c3-bceefc3e86b4.png)
![Screen Shot 2019-03-13 at 16 43 28](https://user-images.githubusercontent.com/4015436/54309971-13c8d400-45b0-11e9-9e5e-7ded7a0e9ed5.png)
