### PR TITLE
(Feature) - Time count in notifications should start from min

### DIFF
--- a/src/components/notifications/notification_item.tsx
+++ b/src/components/notifications/notification_item.tsx
@@ -137,7 +137,7 @@ class NotificationItem extends React.Component<Props, State> {
     };
 
     private readonly _getTextFromItem = (item: Notification): React.ReactNode => {
-        const formatter = (value: any, unit: any, suffix: any) => {
+        const formatter = (value: number, unit: string, suffix: string) => {
             if (unit === 'second') {
                 return 'Just now';
             } else {


### PR DESCRIPTION
Closes #146 

We added a formatting function so we can modify the time of the notifications