### PR TITLE
(Feature) Switched places of orderbook and order

### DIFF
--- a/src/pages/marketplace.tsx
+++ b/src/pages/marketplace.tsx
@@ -16,10 +16,10 @@ class Marketplace extends React.PureComponent {
                     <BuySellContainer />
                 </Sidebar>
                 <MainContent>
-                    <OrderHistoryContainer />
+                    <OrderBookTableContainer />
                 </MainContent>
                 <Sidebar>
-                    <OrderBookTableContainer />
+                    <OrderHistoryContainer />
                 </Sidebar>
             </>
         );


### PR DESCRIPTION
Changes the position of the orderbook to the orders position

It looks like this:
![image](https://user-images.githubusercontent.com/21086218/54766118-7e45c980-4bd9-11e9-8f33-6dd02d93b40e.png)

closes #145 