### PR TITLE
Use modal when locking/unlocking tokens

### DIFF
--- a/src/components/account/wallet_token_balances.test.tsx
+++ b/src/components/account/wallet_token_balances.test.tsx
@@ -69,7 +69,7 @@ describe('WalletTokenBalances', () => {
                 ethBalance={ZERO}
                 wethTokenBalance={wethTokenBalance}
                 tokenBalances={tokenBalances}
-                onToggleTokenLock={noop}
+                onStartToggleTokenLockSteps={noop}
                 web3State={Web3State.Done}
             />,
         );
@@ -121,7 +121,7 @@ describe('WalletTokenBalances', () => {
                 ethBalance={ZERO}
                 wethTokenBalance={wethTokenBalance}
                 tokenBalances={tokenBalances}
-                onToggleTokenLock={noop}
+                onStartToggleTokenLockSteps={noop}
                 web3State={Web3State.Done}
             />,
         );
@@ -182,7 +182,7 @@ describe('WalletTokenBalances', () => {
                 ethBalance={ZERO}
                 wethTokenBalance={wethTokenBalance}
                 tokenBalances={tokenBalances}
-                onToggleTokenLock={onToggleTokenLock}
+                onStartToggleTokenLockSteps={onToggleTokenLock}
                 web3State={Web3State.Done}
             />,
         );
@@ -193,7 +193,7 @@ describe('WalletTokenBalances', () => {
             .simulate('click');
 
         // then
-        expect(onToggleTokenLock).toHaveBeenCalledWith(tokenBalances[1]);
+        expect(onToggleTokenLock).toHaveBeenCalledWith(tokenBalances[1].token, tokenBalances[1].isUnlocked);
     });
 
     it('should call the onToggleTokenLock function when a unlocked token is clicked', () => {
@@ -240,7 +240,7 @@ describe('WalletTokenBalances', () => {
                 ethBalance={ZERO}
                 wethTokenBalance={wethTokenBalance}
                 tokenBalances={tokenBalances}
-                onToggleTokenLock={onToggleTokenLock}
+                onStartToggleTokenLockSteps={onToggleTokenLock}
                 web3State={Web3State.Done}
             />,
         );
@@ -250,6 +250,6 @@ describe('WalletTokenBalances', () => {
             .simulate('click');
 
         // then
-        expect(onToggleTokenLock).toHaveBeenCalledWith(tokenBalances[0]);
+        expect(onToggleTokenLock).toHaveBeenCalledWith(tokenBalances[0].token, tokenBalances[0].isUnlocked);
     });
 });

--- a/src/components/account/wallet_token_balances.tsx
+++ b/src/components/account/wallet_token_balances.tsx
@@ -4,10 +4,10 @@ import React from 'react';
 import { connect } from 'react-redux';
 import styled from 'styled-components';
 
-import { toggleTokenLock } from '../../store/actions';
+import { startToggleTokenLockSteps } from '../../store/actions';
 import { getEthBalance, getTokenBalances, getWeb3State, getWethTokenBalance } from '../../store/selectors';
 import { tokenAmountInUnits } from '../../util/tokens';
-import { StoreState, TokenBalance, Web3State } from '../../util/types';
+import { StoreState, Token, TokenBalance, Web3State } from '../../util/types';
 import { Card } from '../common/card';
 import { TokenIcon } from '../common/icons/token_icon';
 import { CardLoading } from '../common/loading';
@@ -20,7 +20,7 @@ interface StateProps {
     wethTokenBalance: TokenBalance | null;
 }
 interface DispatchProps {
-    onToggleTokenLock: (tokenBalance: TokenBalance) => void;
+    onStartToggleTokenLockSteps: (token: Token, isUnlocked: boolean) => void;
 }
 
 type Props = StateProps & DispatchProps;
@@ -73,7 +73,7 @@ const LockCell = ({ styles, isUnlocked, onClick }: LockCellProps) => {
 
 class WalletTokenBalances extends React.PureComponent<Props> {
     public render = () => {
-        const { ethBalance, tokenBalances, onToggleTokenLock, web3State, wethTokenBalance } = this.props;
+        const { ethBalance, tokenBalances, onStartToggleTokenLockSteps, web3State, wethTokenBalance } = this.props;
 
         if (!wethTokenBalance) {
             return null;
@@ -82,7 +82,7 @@ class WalletTokenBalances extends React.PureComponent<Props> {
         const wethToken = wethTokenBalance.token;
         const totalEth = wethTokenBalance.balance.plus(ethBalance);
         const formattedTotalEthBalance = tokenAmountInUnits(totalEth, wethToken.decimals);
-        const onTotalEthClick = () => onToggleTokenLock(wethTokenBalance);
+        const onTotalEthClick = () => onStartToggleTokenLockSteps(wethTokenBalance.token, wethTokenBalance.isUnlocked);
 
         const totalEthRow = (
             <TR>
@@ -105,7 +105,7 @@ class WalletTokenBalances extends React.PureComponent<Props> {
             const { token, balance, isUnlocked } = tokenBalance;
             const { symbol } = token;
             const formattedBalance = tokenAmountInUnits(balance, token.decimals);
-            const onClick = () => onToggleTokenLock(tokenBalance);
+            const onClick = () => onStartToggleTokenLockSteps(tokenBalance.token, tokenBalance.isUnlocked);
 
             return (
                 <TR key={symbol}>
@@ -164,7 +164,7 @@ const mapStateToProps = (state: StoreState): StateProps => {
     };
 };
 const mapDispatchToProps = {
-    onToggleTokenLock: toggleTokenLock,
+    onStartToggleTokenLockSteps: startToggleTokenLockSteps,
 };
 
 const WalletTokenBalancesContainer = connect(

--- a/src/components/common/steps_modal/steps_modal.tsx
+++ b/src/components/common/steps_modal/steps_modal.tsx
@@ -11,7 +11,7 @@ import { CloseModalButton } from '../icons/close_modal_button';
 import { BuySellTokenStepContainer } from './buy_sell_token_step';
 import { SignOrderStepContainer } from './sign_order_step';
 import { ModalContent } from './steps_common';
-import { UnlockTokensStepContainer } from './unlock_token_step';
+import { ToggleTokenLockStepContainer } from './toggle_token_lock_step';
 import { WrapEthStepContainer } from './wrap_eth_step';
 
 interface StateProps {
@@ -32,7 +32,7 @@ class StepsModal extends React.Component<Props> {
             <Modal isOpen={isOpen} style={themeModalStyle}>
                 <CloseModalButton onClick={reset} />
                 <ModalContent>
-                    {currentStep && currentStep.kind === StepKind.UnlockToken && <UnlockTokensStepContainer />}
+                    {currentStep && currentStep.kind === StepKind.ToggleTokenLock && <ToggleTokenLockStepContainer />}
                     {currentStep && currentStep.kind === StepKind.BuySellLimit && <SignOrderStepContainer />}
                     {currentStep && currentStep.kind === StepKind.BuySellMarket && <BuySellTokenStepContainer />}
                     {currentStep && currentStep.kind === StepKind.WrapEth && <WrapEthStepContainer />}

--- a/src/store/blockchain/actions.ts
+++ b/src/store/blockchain/actions.ts
@@ -47,22 +47,23 @@ export const setWethTokenBalance = createAction('SET_WETH_TOKEN_BALANCE', resolv
     return (wethTokenBalance: TokenBalance | null) => resolve(wethTokenBalance);
 });
 
-export const toggleTokenLock = ({ token, isUnlocked }: TokenBalance) => {
+export const toggleTokenLock = (token: Token, isUnlocked: boolean) => {
     return async (dispatch: any, getState: any) => {
         const state = getState();
         const ethAccount = getEthAccount(state);
 
         const contractWrappers = await getContractWrappers();
 
+        let tx: string;
         if (isUnlocked) {
-            await contractWrappers.erc20Token.setProxyAllowanceAsync(
+            tx = await contractWrappers.erc20Token.setProxyAllowanceAsync(
                 token.address,
                 ethAccount,
                 new BigNumber('0'),
                 TX_DEFAULTS,
             );
         } else {
-            await contractWrappers.erc20Token.setUnlimitedProxyAllowanceAsync(token.address, ethAccount);
+            tx = await contractWrappers.erc20Token.setUnlimitedProxyAllowanceAsync(token.address, ethAccount);
         }
 
         const isWeth = token.symbol === WETH_TOKEN_SYMBOL;
@@ -89,6 +90,8 @@ export const toggleTokenLock = ({ token, isUnlocked }: TokenBalance) => {
 
             dispatch(setTokenBalances(updatedTokenBalances));
         }
+
+        return tx;
     };
 };
 
@@ -260,24 +263,13 @@ export const addWethToBalance = (amount: BigNumber) => {
 
 export const unlockToken = (token: Token) => {
     return async (dispatch: any, getState: any): Promise<any> => {
-        const state = getState();
+        return dispatch(toggleTokenLock(token, false));
+    };
+};
 
-        let tokenBalance: TokenBalance;
-        if (token.symbol === WETH_TOKEN_SYMBOL) {
-            tokenBalance = getWethTokenBalance(state) as TokenBalance;
-        } else {
-            tokenBalance = getTokenBalances(state).find(
-                balance => balance.token.address === token.address,
-            ) as TokenBalance;
-        }
-
-        if (!tokenBalance.isUnlocked) {
-            const ethAccount = getEthAccount(state);
-            const contractWrappers = await getContractWrappers();
-            return contractWrappers.erc20Token.setUnlimitedProxyAllowanceAsync(token.address, ethAccount);
-        } else {
-            return Promise.resolve();
-        }
+export const lockToken = (token: Token) => {
+    return async (dispatch: any, getState: any): Promise<any> => {
+        return dispatch(toggleTokenLock(token, true));
     };
 };
 

--- a/src/store/ui/actions.ts
+++ b/src/store/ui/actions.ts
@@ -11,7 +11,7 @@ import {
     OrderSide,
     Step,
     StepKind,
-    StepUnlockToken,
+    StepToggleTokenLock,
     StepWrapEth,
     StoreState,
     Token,
@@ -91,6 +91,16 @@ export const startBuySellLimitSteps = (amount: BigNumber, price: BigNumber, side
     };
 };
 
+export const startToggleTokenLockSteps = (token: Token, isUnlocked: boolean) => {
+    return async (dispatch: any) => {
+        const toggleTokenLockStep = isUnlocked ? getLockTokenStep(token) : getUnlockTokenStep(token);
+
+        dispatch(setStepsModalCurrentStep(toggleTokenLockStep));
+        dispatch(setStepsModalPendingSteps([]));
+        dispatch(setStepsModalDoneSteps([]));
+    };
+};
+
 export const startBuySellMarketSteps = (amount: BigNumber, side: OrderSide) => {
     return async (dispatch: any, getState: any) => {
         const state = getState();
@@ -165,20 +175,22 @@ const getWrapEthStepIfNeeded = (
     }
 };
 
-const getUnlockZrxStepIfNeeded = (state: StoreState): StepUnlockToken | null => {
+const getUnlockZrxStepIfNeeded = (state: StoreState): StepToggleTokenLock | null => {
     const tokenBalances = selectors.getTokenBalances(state);
     const zrxTokenBalance: TokenBalance = tokenBalances.find(tokenBalance => isZrx(tokenBalance.token)) as TokenBalance;
     if (zrxTokenBalance.isUnlocked) {
         return null;
     } else {
         return {
-            kind: StepKind.UnlockToken,
+            kind: StepKind.ToggleTokenLock,
             token: zrxTokenBalance.token,
+            isUnlocked: false,
+            context: 'order',
         };
     }
 };
 
-const getUnlockTokenStepIfNeeded = (token: Token, state: StoreState): StepUnlockToken | null => {
+const getUnlockTokenStepIfNeeded = (token: Token, state: StoreState): StepToggleTokenLock | null => {
     const tokenBalances = selectors.getTokenBalances(state);
 
     let tokenBalance: TokenBalance;
@@ -194,10 +206,30 @@ const getUnlockTokenStepIfNeeded = (token: Token, state: StoreState): StepUnlock
         return null;
     } else {
         return {
-            kind: StepKind.UnlockToken,
+            kind: StepKind.ToggleTokenLock,
             token: tokenBalance.token,
+            isUnlocked: false,
+            context: 'order',
         };
     }
+};
+
+const getUnlockTokenStep = (token: Token): StepToggleTokenLock => {
+    return {
+        kind: StepKind.ToggleTokenLock,
+        token,
+        isUnlocked: false,
+        context: 'standalone',
+    };
+};
+
+const getLockTokenStep = (token: Token): StepToggleTokenLock => {
+    return {
+        kind: StepKind.ToggleTokenLock,
+        token,
+        isUnlocked: true,
+        context: 'standalone',
+    };
 };
 
 export const createSignedOrder = (amount: BigNumber, price: BigNumber, side: OrderSide) => {

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -66,7 +66,7 @@ export interface StoreState {
 
 export enum StepKind {
     WrapEth = 'WrapEth',
-    UnlockToken = 'UnlockToken',
+    ToggleTokenLock = 'ToggleTokenLock',
     BuySellLimit = 'BuySellLimit',
     BuySellMarket = 'BuySellMarket',
 }
@@ -76,9 +76,11 @@ export interface StepWrapEth {
     amount: BigNumber;
 }
 
-export interface StepUnlockToken {
-    kind: StepKind.UnlockToken;
+export interface StepToggleTokenLock {
+    kind: StepKind.ToggleTokenLock;
     token: Token;
+    isUnlocked: boolean;
+    context: 'order' | 'standalone';
 }
 
 export interface StepBuySellLimitOrder {
@@ -95,7 +97,7 @@ export interface StepBuySellMarket {
     token: Token;
 }
 
-export type Step = StepWrapEth | StepUnlockToken | StepBuySellLimitOrder | StepBuySellMarket;
+export type Step = StepWrapEth | StepToggleTokenLock | StepBuySellLimitOrder | StepBuySellMarket;
 
 export interface StepsModalState {
     readonly doneSteps: Step[];


### PR DESCRIPTION
Part of #158.

Use a modal step when locking/unlocking a token from the my wallet page.

I created a generic "toggle token lock" modal. This checks the info in the step to see if it has to lock or unlock the token, and to show the proper messages.

The title of the modal is different when you are unlocking a token as part of a buy/sell. To handle this, I added a `context` field to the step info. I used a union of string literals because adding an enum for this seemed overkill.

There's a bug here. If you unlock a token, close the modal, and immediately lock or unlock a token, the modal will be open for a while and then it will close itself. This is because the `advanceStep` callback is executed after some seconds. I think this is very unlikely to happen in practice, though.