### PR TITLE
Use modal when wrapping/unwrapping eth

### DIFF
--- a/src/components/account/wallet_weth_balance.tsx
+++ b/src/components/account/wallet_weth_balance.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import styled from 'styled-components';
 
-import { updateWethBalance } from '../../store/actions';
+import { startWrapEtherSteps } from '../../store/actions';
 import { getEthBalance, getWeb3State, getWethBalance } from '../../store/selectors';
 import { themeColors, themeDimensions, themeModalStyle } from '../../util/theme';
 import { tokenAmountInUnits } from '../../util/tokens';
@@ -21,7 +21,7 @@ interface StateProps {
     web3State: Web3State;
 }
 interface DispatchProps {
-    onUpdateWethBalance: (newBalance: BigNumber) => Promise<any>;
+    onStartWrapEtherSteps: (newBalance: BigNumber) => Promise<any>;
 }
 
 type Props = StateProps & DispatchProps;
@@ -205,7 +205,7 @@ class WalletWethBalance extends React.PureComponent<Props, State> {
             isSubmitting: true,
         });
         try {
-            await this.props.onUpdateWethBalance(newWeth);
+            await this.props.onStartWrapEtherSteps(newWeth);
         } finally {
             this.setState({
                 isSubmitting: false,
@@ -235,7 +235,7 @@ const mapStateToProps = (state: StoreState): StateProps => {
     };
 };
 const mapDispatchToProps = {
-    onUpdateWethBalance: updateWethBalance,
+    onStartWrapEtherSteps: startWrapEtherSteps,
 };
 
 const WalletWethBalanceContainer = connect(

--- a/src/store/blockchain/actions.ts
+++ b/src/store/blockchain/actions.ts
@@ -128,18 +128,21 @@ export const updateWethBalance = (newWethBalance: BigNumber) => {
             return;
         }
 
-        await web3Wrapper.awaitTransactionSuccessAsync(tx);
-        const ethBalance = await web3Wrapper.getBalanceInWeiAsync(ethAccount);
-        dispatch(setEthBalance(ethBalance));
+        web3Wrapper.awaitTransactionSuccessAsync(tx).then(async () => {
+            const ethBalance = await web3Wrapper.getBalanceInWeiAsync(ethAccount);
+            dispatch(setEthBalance(ethBalance));
 
-        const newWethTokenBalance = wethTokenBalance
-            ? {
-                  ...wethTokenBalance,
-                  balance: newWethBalance,
-              }
-            : null;
+            const newWethTokenBalance = wethTokenBalance
+                ? {
+                      ...wethTokenBalance,
+                      balance: newWethBalance,
+                  }
+                : null;
 
-        dispatch(setWethTokenBalance(newWethTokenBalance));
+            dispatch(setWethTokenBalance(newWethTokenBalance));
+        });
+
+        return tx;
     };
 };
 
@@ -270,19 +273,6 @@ export const initWallet = () => {
                 }
             }
         }
-    };
-};
-
-export const addWethToBalance = (amount: BigNumber) => {
-    return async (dispatch: any, getState: any) => {
-        const state = getState();
-        const ethAccount = getEthAccount(state);
-
-        const wethToken = getKnownTokens().getWethToken();
-        const wethAddress = wethToken.address;
-
-        const contractWrappers = await getContractWrappers();
-        return contractWrappers.etherToken.depositAsync(wethAddress, amount, ethAccount);
     };
 };
 

--- a/src/store/ui/actions.ts
+++ b/src/store/ui/actions.ts
@@ -105,6 +105,24 @@ export const startToggleTokenLockSteps = (token: Token, isUnlocked: boolean) => 
     };
 };
 
+export const startWrapEtherSteps = (newWethBalance: BigNumber) => {
+    return async (dispatch: any, getState: any) => {
+        const state = getState();
+        const currentWethBalance = selectors.getWethBalance(state);
+
+        const wrapEthStep: StepWrapEth = {
+            kind: StepKind.WrapEth,
+            currentWethBalance,
+            newWethBalance,
+            context: 'standalone',
+        };
+
+        dispatch(setStepsModalCurrentStep(wrapEthStep));
+        dispatch(setStepsModalPendingSteps([]));
+        dispatch(setStepsModalDoneSteps([]));
+    };
+};
+
 export const startBuySellMarketSteps = (amount: BigNumber, side: OrderSide) => {
     return async (dispatch: any, getState: any) => {
         const state = getState();
@@ -172,7 +190,9 @@ const getWrapEthStepIfNeeded = (
     if (deltaWeth.lessThan(0)) {
         return {
             kind: StepKind.WrapEth,
-            amount: deltaWeth.abs(),
+            currentWethBalance: wethBalance,
+            newWethBalance: wethAmount,
+            context: 'order',
         };
     } else {
         return null;

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -74,7 +74,9 @@ export enum StepKind {
 
 export interface StepWrapEth {
     kind: StepKind.WrapEth;
-    amount: BigNumber;
+    currentWethBalance: BigNumber;
+    newWethBalance: BigNumber;
+    context: 'order' | 'standalone';
 }
 
 export interface StepToggleTokenLock {


### PR DESCRIPTION
Closes #158.

Similar to #171, but for wrapping/unwrapping ether.

The step now has the information on the current balance and the new balance. This is necessary to know if the user is converting ETH to wETH or if it's the other way around.

The `buildMessage` function is complex because the message depends on the "direction" of the conversion, and because there is a "for trading" part that's only shown when the conversion is part of building an order.