### PR TITLE
Make networkId mandatory in getKnownTokens

### DIFF
--- a/src/components/common/steps_modal/wrap_eth_step.tsx
+++ b/src/components/common/steps_modal/wrap_eth_step.tsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 
 import { getWeb3WrapperOrThrow } from '../../../services/web3_wrapper';
 import { stepsModalAdvanceStep, updateWethBalance } from '../../../store/actions';
-import { getStepsModalCurrentStep } from '../../../store/selectors';
+import { getNetworkId, getStepsModalCurrentStep } from '../../../store/selectors';
 import { getKnownTokens } from '../../../util/known_tokens';
 import { getStepTitle } from '../../../util/steps';
 import { tokenAmountInUnitsToBigNumber } from '../../../util/tokens';
@@ -28,6 +28,7 @@ interface OwnProps {
     buildStepsProgress: (currentStepItem: StepItem) => StepItem[];
 }
 interface StateProps {
+    networkId: number | null;
     step: StepWrapEth;
 }
 
@@ -52,9 +53,15 @@ class WrapEthStep extends React.Component<Props, State> {
     };
 
     public render = () => {
+        const { networkId } = this.props;
+
+        if (networkId === null) {
+            return null;
+        }
+
         const { context, currentWethBalance, newWethBalance } = this.props.step;
         const amount = newWethBalance.sub(currentWethBalance);
-        const wethToken = getKnownTokens().getWethToken();
+        const wethToken = getKnownTokens(networkId).getWethToken();
         const ethAmount = tokenAmountInUnitsToBigNumber(amount.abs(), wethToken.decimals).toString();
         const { status } = this.state;
         const retry = () => this._retry();
@@ -156,6 +163,7 @@ class WrapEthStep extends React.Component<Props, State> {
 
 const mapStateToProps = (state: StoreState): StateProps => {
     return {
+        networkId: getNetworkId(state),
         step: getStepsModalCurrentStep(state) as StepWrapEth,
     };
 };

--- a/src/components/marketplace/order_details.test.tsx
+++ b/src/components/marketplace/order_details.test.tsx
@@ -41,6 +41,7 @@ describe('OrderDetails', () => {
         // when
         const wrapper = shallow(
             <OrderDetails
+                networkId={CONSTANTS.RELAYER_NETWORK_ID}
                 orderSide={OrderSide.Sell}
                 orderType={OrderType.Limit}
                 tokenAmount={makerAmount}
@@ -119,6 +120,7 @@ describe('OrderDetails', () => {
         // when
         const wrapper = shallow(
             <OrderDetails
+                networkId={CONSTANTS.RELAYER_NETWORK_ID}
                 orderType={OrderType.Market}
                 orderSide={OrderSide.Buy}
                 tokenAmount={makerAmount}
@@ -197,6 +199,7 @@ describe('OrderDetails', () => {
         // when
         const wrapper = shallow(
             <OrderDetails
+                networkId={CONSTANTS.RELAYER_NETWORK_ID}
                 orderType={OrderType.Market}
                 orderSide={OrderSide.Buy}
                 tokenAmount={makerAmount}
@@ -273,6 +276,7 @@ describe('OrderDetails', () => {
         // when
         const wrapper = shallow(
             <OrderDetails
+                networkId={CONSTANTS.RELAYER_NETWORK_ID}
                 orderType={OrderType.Market}
                 orderSide={OrderSide.Buy}
                 tokenAmount={makerAmount}

--- a/src/components/marketplace/order_details.tsx
+++ b/src/components/marketplace/order_details.tsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import styled from 'styled-components';
 
 import { MAKER_FEE } from '../../common/constants';
-import { getOpenBuyOrders, getOpenSellOrders } from '../../store/selectors';
+import { getNetworkId, getOpenBuyOrders, getOpenSellOrders } from '../../store/selectors';
 import { getKnownTokens } from '../../util/known_tokens';
 import { buildMarketOrders } from '../../util/orders';
 import { themeColors } from '../../util/theme';
@@ -74,6 +74,7 @@ interface OwnProps {
 }
 
 interface StateProps {
+    networkId: number | null;
     openSellOrders: UIOrder[];
     openBuyOrders: UIOrder[];
 }
@@ -163,20 +164,27 @@ class OrderDetails extends React.Component<Props, State> {
     };
 
     private readonly _getFeeStringForRender = () => {
+        const { networkId } = this.props;
+        if (networkId === null) {
+            return '';
+        }
         const { feeInZrx } = this.state;
-        const zrxDecimals = getKnownTokens().getTokenBySymbol(TokenSymbol.Zrx).decimals;
+        const zrxDecimals = getKnownTokens(networkId).getTokenBySymbol(TokenSymbol.Zrx).decimals;
         return `${tokenAmountInUnits(feeInZrx, zrxDecimals)} ${TokenSymbol.Zrx.toUpperCase()}`;
     };
 
     private readonly _getCostStringForRender = () => {
         const { canOrderBeFilled } = this.state;
-        const { orderType } = this.props;
+        const { networkId, orderType } = this.props;
+        if (networkId === null) {
+            return '';
+        }
         if (orderType === OrderType.Market && !canOrderBeFilled) {
             return `---`;
         }
 
         const { quote } = this.props.currencyPair;
-        const quoteTokenDecimals = getKnownTokens().getTokenBySymbol(quote).decimals;
+        const quoteTokenDecimals = getKnownTokens(networkId).getTokenBySymbol(quote).decimals;
         const { quoteTokenAmount } = this.state;
         return `${tokenAmountInUnits(quoteTokenAmount, quoteTokenDecimals)} ${quote}`;
     };
@@ -184,6 +192,7 @@ class OrderDetails extends React.Component<Props, State> {
 
 const mapStateToProps = (state: StoreState): StateProps => {
     return {
+        networkId: getNetworkId(state),
         openSellOrders: getOpenSellOrders(state),
         openBuyOrders: getOpenBuyOrders(state),
     };

--- a/src/store/blockchain/actions.ts
+++ b/src/store/blockchain/actions.ts
@@ -55,6 +55,10 @@ export const setGasInfo = createAction('SET_GAS_INFO', resolve => {
     return (gasInfo: GasInfo) => resolve(gasInfo);
 });
 
+export const setNetworkId = createAction('SET_NETWORK_ID', resolve => {
+    return (networkId: number) => resolve(networkId);
+});
+
 export const toggleTokenLock = (token: Token, isUnlocked: boolean) => {
     return async (dispatch: any, getState: any) => {
         const state = getState();

--- a/src/store/blockchain/reducers.ts
+++ b/src/store/blockchain/reducers.ts
@@ -12,6 +12,7 @@ const initialBlockchainState: BlockchainState = {
     tokenBalances: [],
     ethBalance: new BigNumber(0),
     wethTokenBalance: null,
+    networkId: null,
     gasInfo: {
         gasPriceInWei: DEFAULT_GAS_PRICE,
         estimatedTimeMs: DEFAULT_ESTIMATED_TRANSACTION_TIME_MS,
@@ -47,6 +48,8 @@ export function blockchain(state: BlockchainState = initialBlockchainState, acti
                 ...state,
                 ...action.payload,
             };
+        case getType(actions.setNetworkId):
+            return { ...state, networkId: action.payload };
     }
     return state;
 }

--- a/src/store/selectors.ts
+++ b/src/store/selectors.ts
@@ -25,6 +25,7 @@ export const getMarkets = (state: StoreState) => state.market.markets;
 export const getEthInUsd = (state: StoreState) => state.market.ethInUsd;
 export const getGasPriceInWei = (state: StoreState) => state.blockchain.gasInfo.gasPriceInWei;
 export const getEstimatedTxTimeMs = (state: StoreState) => state.blockchain.gasInfo.estimatedTimeMs;
+export const getNetworkId = (state: StoreState) => state.blockchain.networkId;
 
 export const getOpenOrders = createSelector(
     getOrders,

--- a/src/util/known_tokens.ts
+++ b/src/util/known_tokens.ts
@@ -1,4 +1,3 @@
-import { RELAYER_NETWORK_ID } from '../common/constants';
 import { KNOWN_TOKENS_META_DATA, TokenMetaData } from '../common/tokens_meta_data';
 
 import { getWethTokenFromTokensMetaDataByNetworkId, mapTokensMetaDataToTokenByNetworkId } from './token_meta_data';
@@ -47,7 +46,7 @@ export class KnownTokens {
 
 let knownTokens: KnownTokens;
 export const getKnownTokens = (
-    networkId: number = RELAYER_NETWORK_ID,
+    networkId: number,
     knownTokensMetadata: TokenMetaData[] = KNOWN_TOKENS_META_DATA,
 ): KnownTokens => {
     if (!knownTokens) {

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -37,6 +37,7 @@ export interface BlockchainState {
     readonly ethBalance: BigNumber;
     readonly wethTokenBalance: TokenBalance | null;
     readonly gasInfo: GasInfo;
+    readonly networkId: number | null;
 }
 
 export interface RelayerState {


### PR DESCRIPTION
We had some places where we were calling `getKnownTokens` without arguments. This was making it default to using the ganache network id, and that was being cached and used for the remaining calls. So Kovan wasn't working properly because the test tokens addresses were being used.

My solution was to make that parameter mandatory, but that triggered a lot of other changes. I think it's necessary, but there might be a better way to handle this (specifically: we are using `getKnownTokens` for things that don't depend on the network). We can think about that later.