### PR TITLE
Set networkId in store in updateStore action.

### DIFF
--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -3,10 +3,10 @@ import { getTokenBalance, tokenToTokenBalance } from '../services/tokens';
 import { getWeb3WrapperOrThrow } from '../services/web3_wrapper';
 import { getKnownTokens } from '../util/known_tokens';
 
-import { setEthBalance, setNetworkId, setTokenBalances, setWethBalance, updateGasInfo } from './blockchain/actions';
+import { setEthBalance, setTokenBalances, setWethBalance, updateGasInfo } from './blockchain/actions';
 import { getMarkets, setMarketTokens } from './market/actions';
 import { getOrderBook, getOrderbookAndUserOrders } from './relayer/actions';
-import { getCurrencyPair, getNetworkId } from './selectors';
+import { getCurrencyPair } from './selectors';
 
 export * from './blockchain/actions';
 export * from './market/actions';


### PR DESCRIPTION
Closes #206 .

Problem was that the property `networkId` in the `blockchain` attribute from the store was not being set `=>` the redux-connected components that relied on this were misfunctioning.