### PR TITLE
(Hotfix) Unlock only needed tokens

### DIFF
--- a/src/store/ui/actions.ts
+++ b/src/store/ui/actions.ts
@@ -55,24 +55,19 @@ export const startBuySellLimitSteps = (amount: BigNumber, price: BigNumber, side
         const quoteToken = selectors.getQuoteToken(state) as Token;
 
         const buySellLimitFlow: Step[] = [];
-        let unlockQuoteTokenStep;
-        let unlockBaseTokenStep;
+        let unlockBaseOrQuoteTokenStep;
 
         // unlock base and quote tokens if necessary
-        // If it's a buy -> the quote token has to be unlocked
-        if (side === OrderSide.Buy) {
-            unlockQuoteTokenStep = getUnlockTokenStepIfNeeded(quoteToken, state);
-        } else {
-            // If it's a sell -> the base token has to be unlocked
-            unlockBaseTokenStep = getUnlockTokenStepIfNeeded(baseToken, state);
-        }
 
-        if (unlockBaseTokenStep) {
-            buySellLimitFlow.push(unlockBaseTokenStep);
-        }
+        unlockBaseOrQuoteTokenStep =
+            side === OrderSide.Buy
+                ? // If it's a buy -> the quote token has to be unlocked
+                  getUnlockTokenStepIfNeeded(quoteToken, state)
+                : // If it's a sell -> the base token has to be unlocked
+                  getUnlockTokenStepIfNeeded(baseToken, state);
 
-        if (unlockQuoteTokenStep) {
-            buySellLimitFlow.push(unlockQuoteTokenStep);
+        if (unlockBaseOrQuoteTokenStep) {
+            buySellLimitFlow.push(unlockBaseOrQuoteTokenStep);
         }
 
         // unlock zrx (for fees) if it's not one of the traded tokens and if the maker fee is positive


### PR DESCRIPTION
Closes #230 

Only forces the unlock of the token needed for executing each operation:

According to what we discussed [here](https://github.com/0xProject/0x-launch-kit-frontend/issues/230#issuecomment-479622332) and originally posted by @fvictorio:

> I think these are the possible scenarios, and the expected results:
> 
> * If you are creating a **buy** on limit order for a X/Y market, your Y has to be unlocked.
> * If you are creating a **sell** on limit order for a X/Y market, your X has to be unlocked.
> * If you are creating an order, and there is a positive maker fee, your ZRX has to be unlocked.
> * If you are filling an order, the taker asset has to be unlocked.
>   
>   * Also, if the taker fee is positive, your ZRX has to be unlocked.