### PR TITLE
networkId is not set in initWallet action

### DIFF
--- a/src/store/blockchain/actions.ts
+++ b/src/store/blockchain/actions.ts
@@ -298,6 +298,7 @@ export const initWallet = () => {
                     ethBalance,
                     wethTokenBalance,
                     tokenBalances,
+                    networkId,
                 }),
             );
             dispatch(


### PR DESCRIPTION
The action `initWallet` from `src/store/blockchain/actions.ts` was not setting `blockchain.networkId` in the store. Order details has a couple of methods that check this before rendering the Fee and Cost strings.

Something happened to the file between commit https://github.com/0xProject/0x-launch-kit-frontend/commit/97c3e35542462d474f58de3106086f8f9a7699c2#diff-c108e98d0adb02a0bb78eb0657a19bf1 and https://github.com/0xProject/0x-launch-kit-frontend/commit/8415d32202c31d509a98487aa77fd83c35510028#diff-c108e98d0adb02a0bb78eb0657a19bf1.

The [file history](https://github.com/0xProject/0x-launch-kit-frontend/commits/development/src/store/blockchain/actions.ts) doesn't show that the corresponding dispatch/line was removed, but it is not clearly present in the 2nd commit listed here and neither it is shown as removed in its diff.