### PR TITLE
(fix) improve numbers' legibility

### DIFF
--- a/src/components/account/wallet_token_balances.tsx
+++ b/src/components/account/wallet_token_balances.tsx
@@ -90,9 +90,11 @@ class WalletTokenBalances extends React.PureComponent<Props> {
                     <TokenIconStyled symbol={wethToken.symbol} primaryColor={wethToken.primaryColor} />
                 </TokenTD>
                 <CustomTDTokenName styles={{ borderBottom: true }}>ETH Total (ETH + wETH)</CustomTDTokenName>
-                <CustomTD styles={{ borderBottom: true, textAlign: 'right' }}>{formattedTotalEthBalance}</CustomTD>
-                <CustomTD styles={{ borderBottom: true, textAlign: 'right' }}>-</CustomTD>
-                <CustomTD styles={{ borderBottom: true, textAlign: 'right' }}>-</CustomTD>
+                <CustomTD styles={{ borderBottom: true, textAlign: 'right', tabular: true }}>
+                    {formattedTotalEthBalance}
+                </CustomTD>
+                <CustomTD styles={{ borderBottom: true, textAlign: 'right', tabular: true }}>-</CustomTD>
+                <CustomTD styles={{ borderBottom: true, textAlign: 'right', tabular: true }}>-</CustomTD>
                 <LockCell
                     isUnlocked={wethTokenBalance.isUnlocked}
                     onClick={onTotalEthClick}

--- a/src/components/account/wallet_weth_balance.tsx
+++ b/src/components/account/wallet_weth_balance.tsx
@@ -73,6 +73,7 @@ const Label = styled.span`
 const Value = styled.div`
     color: #000;
     flex-shrink: 0;
+    font-feature-settings: 'tnum' 1;
     font-size: 16px;
     font-weight: 700;
     line-height: 1.2;

--- a/src/components/account/wallet_weth_modal.tsx
+++ b/src/components/account/wallet_weth_modal.tsx
@@ -103,6 +103,7 @@ interface EthBoxProps {
 
 const EthBoxValue = styled.h2<EthBoxProps>`
     color: ${props => (props.isZero ? '#666' : themeColors.darkBlue)};
+    font-feature-settings: 'tnum' 1;
     font-size: 24px;
     font-weight: 600;
     line-height: 1.2;
@@ -136,6 +137,7 @@ const SetMinEthButton = styled.a`
 const InputEth = styled<any>(BigNumberInput)`
     border-color: transparent;
     color: ${themeColors.darkBlue};
+    font-feature-settings: 'tnum' 1;
     font-size: 24px;
     font-weight: 600;
     height: 28px;

--- a/src/components/common/markets_dropdown.tsx
+++ b/src/components/common/markets_dropdown.tsx
@@ -350,7 +350,7 @@ class MarketsDropdown extends React.Component<Props, State> {
                                         </TokenLabel>
                                     </TokenIconAndLabel>
                                 </CustomTDFirstStyled>
-                                <CustomTDLastStyled styles={{ textAlign: 'center', borderBottom: true }}>
+                                <CustomTDLastStyled styles={{ textAlign: 'center', borderBottom: true, tabular: true }}>
                                     {this._getPrice(market)}
                                 </CustomTDLastStyled>
                             </TRStyled>

--- a/src/components/marketplace/buy_sell.tsx
+++ b/src/components/marketplace/buy_sell.tsx
@@ -105,6 +105,7 @@ const fieldStyle = `
     border: 1px solid ${themeColors.borderColor};
     border-radius: ${themeDimensions.borderRadius};
     color: #000;
+    font-feature-settings: 'tnum' 1;
     font-size: 16px;
     height: 100%;
     padding-left: 14px;

--- a/src/components/marketplace/order_details.tsx
+++ b/src/components/marketplace/order_details.tsx
@@ -20,7 +20,7 @@ const Row = styled.div`
     position: relative;
     z-index: 1;
 
-    &: last-of-type {
+    &:last-of-type {
         margin-bottom: 20px;
     }
 `;
@@ -28,12 +28,14 @@ const Row = styled.div`
 const Value = styled.div`
     color: #000;
     flex-shrink: 0;
+    font-feature-settings: 'tnum' 1;
     font-size: 14px;
     line-height: 1.2;
     white-space: nowrap;
 `;
 
 const CostValue = styled(Value)`
+    font-feature-settings: 'tnum' 1;
     font-weight: bold;
 `;
 

--- a/src/components/marketplace/order_history.tsx
+++ b/src/components/marketplace/order_history.tsx
@@ -56,9 +56,9 @@ const orderToRow = (order: UIOrder, index: number, baseToken: Token) => {
     return (
         <TR key={index}>
             <SideTD side={order.side}>{sideLabel}</SideTD>
-            <CustomTD styles={{ textAlign: 'right' }}>{size}</CustomTD>
-            <CustomTD styles={{ textAlign: 'right' }}>{filled}</CustomTD>
-            <CustomTD styles={{ textAlign: 'right' }}>{price}</CustomTD>
+            <CustomTD styles={{ textAlign: 'right', tabular: true }}>{size}</CustomTD>
+            <CustomTD styles={{ textAlign: 'right', tabular: true }}>{filled}</CustomTD>
+            <CustomTD styles={{ textAlign: 'right', tabular: true }}>{price}</CustomTD>
             <CustomTD>{status}</CustomTD>
             <CustomTD styles={{ textAlign: 'center' }}>
                 {isOrderFillable ? <CancelOrderButtonContainer order={order} /> : ''}

--- a/src/components/marketplace/wallet_balance.tsx
+++ b/src/components/marketplace/wallet_balance.tsx
@@ -66,6 +66,7 @@ const Label = styled.span`
 
 const Value = styled.span`
     color: #000;
+    font-feature-settings: 'tnum' 1;
     flex-shrink: 0;
     font-size: 16px;
     font-weight: 600;


### PR DESCRIPTION
Closes #245

All number should be easier to read now.

Used `font-feature-settings: 'tnum' 1;` instead of the suggested `font-variant-numeric: tabular-nums;`

The result is exactly the same, but the former option was already implemented (not always enabled though).