### PR TITLE
(fix) timeline alignment

### DIFF
--- a/src/components/common/steps_modal/steps_progress.tsx
+++ b/src/components/common/steps_modal/steps_progress.tsx
@@ -3,8 +3,8 @@ import styled from 'styled-components';
 
 export interface StepItem {
     active: boolean;
-    title: string;
     progress: string;
+    title: string;
 }
 
 interface Props extends HTMLAttributes<HTMLDivElement> {
@@ -15,6 +15,8 @@ const StepsProgressWrapper = styled.div`
     align-items: center;
     display: flex;
     justify-content: space-between;
+    margin-bottom: 20px;
+    margin-top: auto;
     padding-top: 22px;
     width: 100%;
 `;


### PR DESCRIPTION
Closes #231 

Original issue has no description, but I think it means that 

![Screen Shot 2019-04-09 at 09 01 30](https://user-images.githubusercontent.com/4015436/55800048-2946f600-5aa9-11e9-9048-6e0d71e2c774.png)

Should look like

![Screen Shot 2019-04-09 at 09 05 17](https://user-images.githubusercontent.com/4015436/55800068-36fc7b80-5aa9-11e9-90e7-4216354ecd67.png)

So I fixed that.