### PR TITLE
(Hotfix) Fix default auto update

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -31,13 +31,13 @@ export const UI_DECIMALS_DISPLAYED_PRICE_ETH = 7;
 
 export const METAMASK_EXTENSION_URL = 'https://metamask.io/';
 
-// Default value is disabled
+// Default value is enabled, 0 is disabled
 export const UI_UPDATE_CHECK_INTERVAL: number =
-    Number.parseInt(process.env.REACT_APP_UI_UPDATE_CHECK_INTERVAL as string, 10) || 0;
+    Number.parseInt(process.env.REACT_APP_UI_UPDATE_CHECK_INTERVAL as string, 10) || 5000;
 
-// Default value is disabled
+// Default value is enabled, 0 is disabled
 export const UPDATE_ETHER_PRICE_INTERVAL: number =
-    Number.parseInt(process.env.REACT_APP_UPDATE_ETHER_PRICE_INTERVAL as string, 10) || 0;
+    Number.parseInt(process.env.REACT_APP_UPDATE_ETHER_PRICE_INTERVAL as string, 10) || 3600000;
 
 export const NOTIFICATIONS_LIMIT: number =
     Number.parseInt(process.env.REACT_APP_NOTIFICATIONS_LIMIT as string, 10) || 20;


### PR DESCRIPTION
Before If the user does not have an .env with a value bigger than 0 on `REACT_APP_UI_UPDATE_CHECK_INTERVAL` and `REACT_APP_UPDATE_ETHER_PRICE_INTERVAL`

the UI was not updated, now the default is to enable those updates.