### PR TITLE
Store collectibles list sort & filter values in URL search params

### DIFF
--- a/src/components/erc721/collectibles/collectibles_list.tsx
+++ b/src/components/erc721/collectibles/collectibles_list.tsx
@@ -1,8 +1,10 @@
+import queryString from 'query-string';
 import React from 'react';
 import { connect } from 'react-redux';
 import styled, { css } from 'styled-components';
 
-import { getOtherUsersCollectibles, getUserCollectibles } from '../../../store/selectors';
+import { setCollectiblesListFilterType, setCollectiblesListSortType } from '../../../store/actions';
+import { getOtherUsersCollectibles, getRouterLocationSearch, getUserCollectibles } from '../../../store/selectors';
 import { themeBreakPoints } from '../../../themes/commons';
 import { CollectibleFilterType } from '../../../util/filterable_collectibles';
 import { CollectibleSortType } from '../../../util/sortable_collectibles';
@@ -18,14 +20,15 @@ interface OwnProps {
 
 interface StateProps {
     collectibles: { [key: string]: Collectible };
+    search: string;
 }
 
-type Props = StateProps & OwnProps;
-
-interface State {
-    filterType: CollectibleFilterType;
-    sortType: CollectibleSortType;
+interface DispatchProps {
+    setSortType: (sortType: CollectibleSortType | null) => any;
+    setFilterType: (filterType: CollectibleFilterType | null) => any;
 }
+
+type Props = OwnProps & StateProps & DispatchProps;
 
 const MainContainer = styled.div`
     display: flex;
@@ -94,16 +97,16 @@ const Title = styled.h1`
     }
 `;
 
-export class CollectiblesList extends React.Component<Props, State> {
-    public state = {
-        sortType: CollectibleSortType.NewestAdded,
-        filterType: CollectibleFilterType.ShowAll,
+export class CollectiblesList extends React.Component<Props, {}> {
+    public componentWillUnmount = () => {
+        this.props.setSortType(null);
+        this.props.setFilterType(null);
     };
 
     public render = () => {
-        const { title } = this.props;
+        const { title, search } = this.props;
         const collectibles = Object.keys(this.props.collectibles).map(key => this.props.collectibles[key]);
-        const { sortType, filterType } = this.state;
+        const { sortType, filterType } = this._getSortTypeAndFilterTypeFromLocationSearch(search);
 
         return (
             <MainContainer>
@@ -118,24 +121,54 @@ export class CollectiblesList extends React.Component<Props, State> {
     };
 
     private readonly _onChangeSortType = (evt: React.ChangeEvent<HTMLInputElement>) => {
-        this.setState({ sortType: evt.target.value as CollectibleSortType });
+        this.props.setSortType(evt.target.value as CollectibleSortType);
     };
 
     private readonly _onChangeFilterType = (evt: React.ChangeEvent<HTMLInputElement>) => {
-        this.setState({ filterType: evt.target.value as CollectibleFilterType });
+        this.props.setFilterType(evt.target.value as CollectibleFilterType);
+    };
+
+    private readonly _getSortTypeAndFilterTypeFromLocationSearch = (search: string) => {
+        const parsedSearch = queryString.parse(search);
+        return {
+            sortType: (parsedSearch.sort as CollectibleSortType) || CollectibleSortType.NewestAdded,
+            filterType: (parsedSearch.filter as CollectibleFilterType) || CollectibleFilterType.ShowAll,
+        };
     };
 }
 
+// "All Collectibles" and "My Collectibles" get different selectors
 const allMapStateToProps = (state: StoreState): StateProps => {
     return {
         collectibles: getOtherUsersCollectibles(state),
+        search: getRouterLocationSearch(state),
     };
 };
-export const AllCollectiblesListContainer = connect(allMapStateToProps)(CollectiblesList);
 
 const myMapStateToProps = (state: StoreState): StateProps => {
     return {
         collectibles: getUserCollectibles(state),
+        search: getRouterLocationSearch(state),
     };
 };
-export const MyCollectiblesListContainer = connect(myMapStateToProps)(CollectiblesList);
+
+const mapDispatchToProps = (dispatch: any): DispatchProps => {
+    return {
+        setSortType: (sortType: CollectibleSortType | null) => {
+            dispatch(setCollectiblesListSortType(sortType));
+        },
+        setFilterType: (filterType: CollectibleFilterType | null) => {
+            dispatch(setCollectiblesListFilterType(filterType));
+        },
+    };
+};
+
+export const AllCollectiblesListContainer = connect(
+    allMapStateToProps,
+    mapDispatchToProps,
+)(CollectiblesList);
+
+export const MyCollectiblesListContainer = connect(
+    myMapStateToProps,
+    mapDispatchToProps,
+)(CollectiblesList);

--- a/src/components/erc721/collectibles/collectibles_list_filter.tsx
+++ b/src/components/erc721/collectibles/collectibles_list_filter.tsx
@@ -16,11 +16,11 @@ interface Props {
     onChange: (evt: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
-const options: CollectibleFilterType[] = [
-    CollectibleFilterType.ShowAll,
-    CollectibleFilterType.FixedPrice,
-    CollectibleFilterType.DecliningAuction,
-];
+const options: { [key: string]: string } = {
+    [CollectibleFilterType.ShowAll]: 'Show all',
+    [CollectibleFilterType.FixedPrice]: 'Fixed Price',
+    [CollectibleFilterType.DecliningAuction]: 'Declining Auction',
+};
 
 const DropdownItemFilter = styled(DropdownTextItemWrapper)`
     ${props => (props.active ? 'cursor: default;' : '')}
@@ -53,16 +53,17 @@ const Text = styled.span`
 
 export const CollectiblesListFilter = (props: Props) => {
     const { currentValue, onChange, ...restProps } = props;
+    const filterTypes = Object.keys(options) as CollectibleFilterType[];
 
-    const header = <DropdownButton text={currentValue} extraIcon={<FilterIcon />} />;
+    const header = <DropdownButton text={options[currentValue]} extraIcon={<FilterIcon />} />;
 
     const body = (
         <DropdownContainer>
-            {options.map(option => (
-                <DropdownItemFilter key={option} active={currentValue === option}>
-                    <input checked={currentValue === option} onChange={onChange} type="radio" value={option} />
-                    {currentValue === option ? <RadioIconActive /> : <RadioIcon />}
-                    <Text>{option}</Text>
+            {filterTypes.map(filterType => (
+                <DropdownItemFilter key={filterType} active={currentValue === filterType}>
+                    <input checked={currentValue === filterType} onChange={onChange} type="radio" value={filterType} />
+                    {currentValue === filterType ? <RadioIconActive /> : <RadioIcon />}
+                    <Text>{options[filterType]}</Text>
                 </DropdownItemFilter>
             ))}
         </DropdownContainer>

--- a/src/components/erc721/collectibles/collectibles_list_sort.tsx
+++ b/src/components/erc721/collectibles/collectibles_list_sort.tsx
@@ -14,11 +14,11 @@ interface Props {
     onChange: (evt: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
-const options: CollectibleSortType[] = [
-    CollectibleSortType.NewestAdded,
-    CollectibleSortType.PriceLowToHigh,
-    CollectibleSortType.PriceHighToLow,
-];
+const options: { [key: string]: string } = {
+    [CollectibleSortType.NewestAdded]: 'Newest Added',
+    [CollectibleSortType.PriceLowToHigh]: 'Price: low to high',
+    [CollectibleSortType.PriceHighToLow]: 'Pirce: high to low',
+};
 
 const DropdownItemFilter = styled(DropdownTextItemWrapper)`
     ${props => (props.active ? 'cursor: default;' : '')}
@@ -52,15 +52,16 @@ const Text = styled.span`
 
 export const CollectiblesListSort = (props: Props) => {
     const { currentValue, onChange, ...restProps } = props;
+    const sortTypes = Object.keys(options) as CollectibleSortType[];
 
-    const header = <DropdownButton text={currentValue} extraIcon={<SortIcon />} />;
+    const header = <DropdownButton text={options[currentValue]} extraIcon={<SortIcon />} />;
 
     const body = (
         <DropdownContainer>
-            {options.map(option => (
-                <DropdownItemFilter key={option} active={currentValue === option}>
-                    <input type="radio" value={option} checked={currentValue === option} onChange={onChange} />
-                    <Text>{option}</Text>
+            {sortTypes.map(sortType => (
+                <DropdownItemFilter key={sortType} active={currentValue === sortType}>
+                    <input type="radio" value={sortType} checked={currentValue === sortType} onChange={onChange} />
+                    <Text>{options[sortType]}</Text>
                 </DropdownItemFilter>
             ))}
         </DropdownContainer>

--- a/src/components/erc721/collectibles/collectibles_list_sort.tsx
+++ b/src/components/erc721/collectibles/collectibles_list_sort.tsx
@@ -17,7 +17,7 @@ interface Props {
 const options: { [key: string]: string } = {
     [CollectibleSortType.NewestAdded]: 'Newest Added',
     [CollectibleSortType.PriceLowToHigh]: 'Price: low to high',
-    [CollectibleSortType.PriceHighToLow]: 'Pirce: high to low',
+    [CollectibleSortType.PriceHighToLow]: 'Price: high to low',
 };
 
 const DropdownItemFilter = styled(DropdownTextItemWrapper)`

--- a/src/store/router/actions.ts
+++ b/src/store/router/actions.ts
@@ -1,6 +1,9 @@
-import { push } from 'connected-react-router';
+import { push, replace } from 'connected-react-router';
+import queryString from 'query-string';
 
 import { ERC20_APP_BASE_PATH, ERC721_APP_BASE_PATH } from '../../common/constants';
+import { CollectibleFilterType } from '../../util/filterable_collectibles';
+import { CollectibleSortType } from '../../util/sortable_collectibles';
 import { ThunkCreator } from '../../util/types';
 
 export const goToHomeErc20: ThunkCreator = () => {
@@ -63,6 +66,48 @@ export const goToIndividualCollectible = (collectibleId: string) => {
             push({
                 ...state.router.location,
                 pathname: `${ERC721_APP_BASE_PATH}/collectible/${collectibleId}`,
+            }),
+        );
+    };
+};
+
+export const setCollectiblesListSortType = (sortType: CollectibleSortType | null) => {
+    return async (dispatch: any, getState: any) => {
+        const state = getState();
+        const searchObject = {
+            ...queryString.parse(state.router.location.search),
+            sort: sortType,
+        };
+
+        if (sortType === null) {
+            delete searchObject.sort;
+        }
+
+        dispatch(
+            replace({
+                ...state.router.location,
+                search: queryString.stringify(searchObject),
+            }),
+        );
+    };
+};
+
+export const setCollectiblesListFilterType = (filterType: CollectibleFilterType | null) => {
+    return async (dispatch: any, getState: any) => {
+        const state = getState();
+        const searchObject = {
+            ...queryString.parse(state.router.location.search),
+            filter: filterType,
+        };
+
+        if (filterType === null) {
+            delete searchObject.filter;
+        }
+
+        dispatch(
+            replace({
+                ...state.router.location,
+                search: queryString.stringify(searchObject),
             }),
         );
     };

--- a/src/store/selectors.ts
+++ b/src/store/selectors.ts
@@ -42,6 +42,7 @@ export const getCollectibleById = (state: StoreState, props: { collectibleId: st
     state.collectibles.allCollectibles[props.collectibleId];
 export const getSelectedCollectible = (state: StoreState) => state.collectibles.collectibleSelected;
 export const getCurrentRoutePath = (state: StoreState) => state.router.location.pathname;
+export const getRouterLocationSearch = (state: StoreState) => state.router.location.search;
 
 const searchToken = ({ tokenBalances, tokenToFind, wethTokenBalance }: SearchTokenBalanceObject) => {
     if (tokenToFind && isWeth(tokenToFind.symbol)) {

--- a/src/util/filterable_collectibles.ts
+++ b/src/util/filterable_collectibles.ts
@@ -3,9 +3,9 @@ import { SortableCollectible } from './sortable_collectibles';
 import { Collectible } from './types';
 
 export enum CollectibleFilterType {
-    ShowAll = 'Show all',
-    FixedPrice = 'Fixed Price',
-    DecliningAuction = 'Declining Auction',
+    ShowAll = 'show_all',
+    FixedPrice = 'fixed_price',
+    DecliningAuction = 'declining_auction',
 }
 
 const isCollectibleSoldInDutchAuction = (collectible: Collectible): boolean => {

--- a/src/util/sortable_collectibles.ts
+++ b/src/util/sortable_collectibles.ts
@@ -18,12 +18,12 @@ export enum CollectibleSortType {
 export const getCompareFunctionForSort = (sortType: CollectibleSortType) => {
     switch (sortType) {
         case CollectibleSortType.PriceLowToHigh:
-            return (a: SortableCollectible, b: SortableCollectible) => compareAscending(a.price, b.price);
+            return (a: SortableCollectible, b: SortableCollectible) => compareAscending(a.price, b.price, false);
         case CollectibleSortType.PriceHighToLow:
-            return (a: SortableCollectible, b: SortableCollectible) => compareAscending(a.price, b.price) * -1;
+            return (a: SortableCollectible, b: SortableCollectible) => compareAscending(a.price, b.price, true);
         default:
             return (a: SortableCollectible, b: SortableCollectible) =>
-                compareAscending(a.creationDate, b.creationDate) * -1;
+                compareAscending(a.creationDate, b.creationDate, true);
     }
 };
 
@@ -33,12 +33,12 @@ enum CompareOrder {
     Equals = 0,
 }
 
-export const compareAscending = (a: BigNumber | null, b: BigNumber | null): CompareOrder => {
+export const compareAscending = (a: BigNumber | null, b: BigNumber | null, invert: boolean): CompareOrder => {
     // If both are null, they are equal
     if (a === null && b === null) {
         return CompareOrder.Equals;
     }
-    // If only one is a BigNumber, it should come first
+    // If only one is a BigNumber, "it should come first"
     if (a !== null && b === null) {
         return CompareOrder.AFirst;
     } else if (a === null && b !== null) {
@@ -50,7 +50,9 @@ export const compareAscending = (a: BigNumber | null, b: BigNumber | null): Comp
     if (valueA.isEqualTo(valueB)) {
         return CompareOrder.Equals;
     } else {
-        return valueA.isLessThan(valueB) ? CompareOrder.AFirst : CompareOrder.BFirst;
+        // If invert is set, we are toggling the order, although the null value treatment is the same
+        const ascendingResult = valueA.isLessThan(valueB) ? CompareOrder.AFirst : CompareOrder.BFirst;
+        return invert ? ascendingResult * -1 : ascendingResult;
     }
 };
 

--- a/src/util/sortable_collectibles.ts
+++ b/src/util/sortable_collectibles.ts
@@ -10,9 +10,9 @@ export interface SortableCollectible {
 }
 
 export enum CollectibleSortType {
-    PriceLowToHigh = 'Price: low to high',
-    PriceHighToLow = 'Price: hight to low',
-    NewestAdded = 'Newest Added',
+    PriceLowToHigh = 'price_low_to_high',
+    PriceHighToLow = 'price_high_to_low',
+    NewestAdded = 'newest_added',
 }
 
 export const getCompareFunctionForSort = (sortType: CollectibleSortType) => {


### PR DESCRIPTION
Connects #320.
Connects #321.

### Includes

- Move the texts of `CollectibleSortType` and `CollectibleFilterType` to their corresponding dropdowns UI components (previously, was using their string values, but now I use them as the values in the URL).
- Store collectibles list sort and filter values in the URL search params. Use `connected-react-router` action `replace` for this so the UI doesn't add history entries when changing the values.
- Fix `compareAscending` function in `util/sortable_collectibles.ts`: the "inverted" functions were putting the collectibles that lacked an order first.

### Does not include

- Spinner, yet.

### Preview

![sort_filter](https://user-images.githubusercontent.com/4421917/58180542-ace72b80-7c80-11e9-9a5d-10fba4ad23f8.gif)

