### PR TITLE
(Hotfix) Fixs "my wallet link" color on dark theme

### DIFF
--- a/src/components/erc20/common/toolbar_content.tsx
+++ b/src/components/erc20/common/toolbar_content.tsx
@@ -25,7 +25,7 @@ type Props = DispatchProps & OwnProps;
 
 const MyWalletLink = styled.a`
     align-items: center;
-    color: #333333;
+    color: ${props => props.theme.componentsTheme.myWalletLinkColor};
     display: flex;
     font-size: 16px;
     font-weight: 500;

--- a/src/themes/commons.ts
+++ b/src/themes/commons.ts
@@ -74,6 +74,7 @@ export interface ThemeProperties {
     topbarBackgroundColor: string;
     topbarBorderColor: string;
     topbarSeparatorColor: string;
+    myWalletLinkColor: string;
 }
 
 export interface ThemeModalStyle {

--- a/src/themes/dark_theme.ts
+++ b/src/themes/dark_theme.ts
@@ -98,6 +98,7 @@ const darkThemeColors: ThemeProperties = {
     topbarBackgroundColor: '#202123',
     topbarBorderColor: '#000',
     topbarSeparatorColor: '#5A5A5A',
+    myWalletLinkColor: '#fff',
 };
 
 export class DarkTheme extends DefaultTheme {

--- a/src/themes/default_theme.ts
+++ b/src/themes/default_theme.ts
@@ -97,6 +97,7 @@ const lightThemeColors: ThemeProperties = {
     topbarBackgroundColor: '#fff',
     topbarBorderColor: '#dedede',
     topbarSeparatorColor: '#dedede',
+    myWalletLinkColor: '#333333',
 };
 
 export class DefaultTheme implements Theme {


### PR DESCRIPTION
Closes #451 
Before:
![image](https://user-images.githubusercontent.com/21086218/58345868-c7abd280-7e2f-11e9-80a7-857d3c292a4e.png)
After:
![image](https://user-images.githubusercontent.com/21086218/58345921-eb6f1880-7e2f-11e9-9dd6-ca5a0cd0706b.png)
## Description
* Adds myWalletLinkColor to the theme props
* Fixs the wrong color on dark theme