### PR TITLE
Add rate limiting for opensea and relayer

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
         "@0x/connect": "^5.0.8",
         "@0x/web3-wrapper": "^6.0.6",
         "@types/recharts": "^1.1.16",
+        "async-sema": "^3.0.0",
         "connected-react-router": "^6.2.2",
         "history": "^4.7.2",
         "http-proxy-middleware": "^0.19.1",

--- a/src/services/collectibles_metadata_sources/index.ts
+++ b/src/services/collectibles_metadata_sources/index.ts
@@ -5,7 +5,7 @@ import { Mocked } from './mocked';
 import { Opensea } from './opensea';
 
 const sources: { [key: string]: CollectibleMetadataSource } = {
-    opensea: new Opensea(),
+    opensea: new Opensea({ rps: 5 }),
     mocked: new Mocked(),
 };
 

--- a/src/services/relayer.ts
+++ b/src/services/relayer.ts
@@ -5,10 +5,10 @@ import { RELAYER_URL } from '../common/constants';
 import { Token } from '../util/types';
 
 export class Relayer {
-    public readonly client: HttpClient;
+    private readonly _client: HttpClient;
 
     constructor(client: HttpClient) {
-        this.client = client;
+        this._client = client;
     }
 
     public async getAllOrdersAsync(baseTokenAssetData: string, quoteTokenAssetData: string): Promise<SignedOrder[]> {
@@ -21,7 +21,7 @@ export class Relayer {
     }
 
     public async getOrderConfigAsync(orderConfig: OrderConfigRequest): Promise<OrderConfigResponse> {
-        return this.client.getOrderConfigAsync(orderConfig);
+        return this._client.getOrderConfigAsync(orderConfig);
     }
 
     public async getUserOrdersAsync(
@@ -38,7 +38,7 @@ export class Relayer {
     }
 
     public async getCurrencyPairPriceAsync(baseToken: Token, quoteToken: Token): Promise<BigNumber | null> {
-        const { asks } = await this.client.getOrderbookAsync({
+        const { asks } = await this._client.getOrderbookAsync({
             baseAssetData: assetDataUtils.encodeERC20AssetData(baseToken.address),
             quoteAssetData: assetDataUtils.encodeERC20AssetData(quoteToken.address),
         });
@@ -58,7 +58,7 @@ export class Relayer {
         collectibleAddress: string,
         wethAddress: string,
     ): Promise<SignedOrder[]> {
-        const result = await this.client.getOrdersAsync({
+        const result = await this._client.getOrdersAsync({
             makerAssetProxyId: AssetProxyId.ERC721,
             takerAssetProxyId: AssetProxyId.ERC20,
             makerAssetAddress: collectibleAddress,
@@ -66,6 +66,10 @@ export class Relayer {
         });
 
         return result.records.map(record => record.order);
+    }
+
+    public async submitOrderAsync(order: SignedOrder): Promise<void> {
+        return this._client.submitOrderAsync(order);
     }
 
     private async _getOrdersAsync(
@@ -84,7 +88,7 @@ export class Relayer {
         let page = 1;
 
         while (hasMorePages) {
-            const { total, records, perPage } = await this.client.getOrdersAsync({
+            const { total, records, perPage } = await this._client.getOrdersAsync({
                 ...requestOpts,
                 page,
             });

--- a/src/store/relayer/actions.ts
+++ b/src/store/relayer/actions.ts
@@ -87,7 +87,7 @@ export const cancelOrder: ThunkCreator = (order: UIOrder) => {
 export const submitCollectibleOrder: ThunkCreator = (signedOrder: SignedOrder) => {
     return async dispatch => {
         try {
-            const submitResult = await getRelayer().client.submitOrderAsync(signedOrder);
+            const submitResult = await getRelayer().submitOrderAsync(signedOrder);
             // tslint:disable-next-line:no-floating-promises
             dispatch(getAllCollectibles());
             // TODO: Dispatch notification
@@ -103,7 +103,7 @@ export const submitLimitOrder: ThunkCreator = (signedOrder: SignedOrder, amount:
         const state = getState();
         const baseToken = getBaseToken(state) as Token;
         try {
-            const submitResult = await getRelayer().client.submitOrderAsync(signedOrder);
+            const submitResult = await getRelayer().submitOrderAsync(signedOrder);
 
             // tslint:disable-next-line:no-floating-promises
             dispatch(getOrderbookAndUserOrders());

--- a/yarn.lock
+++ b/yarn.lock
@@ -2249,6 +2249,11 @@ async-limiter@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
 
+async-sema@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/async-sema/-/async-sema-3.0.0.tgz#9e22d6783f0ab66a1cf330e21a905e39b3b3a975"
+  integrity sha512-zyCMBDl4m71feawrxYcVbHxv/UUkqm4nKJiLu3+l9lfiQha6jQ/9dxhrXLnzzBXVFqCTDwiUkZOz9XFbdEGQsg==
+
 async@2.6.1, async@^2.0.1, async@^2.1.2, async@^2.4.0, async@^2.5.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.1.tgz#b245a23ca71930044ec53fa46aa00a3e87c6a610"


### PR DESCRIPTION
Part of #469. I won't close that one yet because this can be further improved.

This is probably easier to review commit by commit. The one that makes `client` private is meant to make sure that every relayer request is rate limited.