### PR TITLE
(Fix) Added z-index for notification wrapper

### DIFF
--- a/src/components/notifications/notifications_dropdown.tsx
+++ b/src/components/notifications/notifications_dropdown.tsx
@@ -23,7 +23,9 @@ interface DispatchProps {
 
 type Props = HTMLAttributes<HTMLDivElement> & StateProps & DispatchProps;
 
-const NotificationsDropdownWrapper = styled(Dropdown)``;
+const NotificationsDropdownWrapper = styled(Dropdown)`
+    z-index: 100;
+`;
 
 const NotificationsDropdownHeader = styled.div`
     align-items: center;


### PR DESCRIPTION
Issue: 

Currently the notification z-index is not correct and when account and notification both is opened the 'Convert' button has higher z-index. Notification should always be on the top.

![image](https://user-images.githubusercontent.com/1104560/58611307-84a09380-8263-11e9-8c37-71ded532d598.png)

Fix:
Adding z-index to the notification wrapper
![image](https://user-images.githubusercontent.com/1104560/58611361-ac8ff700-8263-11e9-9cac-f647e502d048.png)
