### PR TITLE
(Feature) Close dropdown on click outside

### DIFF
--- a/src/components/account/wallet_connection_status.tsx
+++ b/src/components/account/wallet_connection_status.tsx
@@ -26,7 +26,7 @@ const WalletConnectionStatusText = styled.span`
 
 interface OwnProps extends HTMLAttributes<HTMLSpanElement> {
     walletConnectionContent: React.ReactNode;
-    shouldShowEthAccountInHeader: boolean;
+    shouldCloseDropdownOnClickOutside?: boolean;
     headerText: string;
     ethAccount: string;
 }
@@ -38,8 +38,8 @@ export class WalletConnectionStatusContainer extends React.PureComponent<Props> 
         const {
             headerText,
             walletConnectionContent,
-            shouldShowEthAccountInHeader,
             ethAccount,
+            shouldCloseDropdownOnClickOutside,
             ...restProps
         } = this.props;
         const status: string = ethAccount ? 'active' : '';
@@ -52,15 +52,13 @@ export class WalletConnectionStatusContainer extends React.PureComponent<Props> 
         );
 
         const body = <>{walletConnectionContent}</>;
-        // If the application is erc720, the dropdown should not close on click outside, because the ethConverter modal won't be usable
         return (
             <Dropdown
                 body={body}
                 header={header}
                 horizontalPosition={DropdownPositions.Right}
+                shouldCloseDropdownOnClickOutside={shouldCloseDropdownOnClickOutside}
                 {...restProps}
-                shouldCloseDropdownOnClickOutside={shouldShowEthAccountInHeader}
-                shouldCloseDropdownBodyOnClick={shouldShowEthAccountInHeader}
             />
         );
     };

--- a/src/components/account/wallet_connection_status.tsx
+++ b/src/components/account/wallet_connection_status.tsx
@@ -1,13 +1,6 @@
-import { BigNumber } from '0x.js';
 import React, { HTMLAttributes } from 'react';
-import { connect } from 'react-redux';
 import styled from 'styled-components';
 
-import { ETH_DECIMALS } from '../../common/constants';
-import { getEthAccount, getEthBalance } from '../../store/selectors';
-import { truncateAddress } from '../../util/number_utils';
-import { tokenAmountInUnits } from '../../util/tokens';
-import { StoreState } from '../../util/types';
 import { Dropdown, DropdownPositions } from '../common/dropdown';
 import { ChevronDownIcon } from '../common/icons/chevron_down_icon';
 
@@ -34,30 +27,22 @@ const WalletConnectionStatusText = styled.span`
 interface OwnProps extends HTMLAttributes<HTMLSpanElement> {
     walletConnectionContent: React.ReactNode;
     shouldShowEthAccountInHeader: boolean;
-}
-
-interface StateProps {
+    headerText: string;
     ethAccount: string;
-    ethBalance: BigNumber;
 }
 
-type Props = StateProps & OwnProps;
+type Props = OwnProps;
 
-class WalletConnectionStatus extends React.PureComponent<Props> {
+export class WalletConnectionStatusContainer extends React.PureComponent<Props> {
     public render = () => {
         const {
-            ethAccount,
-            ethBalance,
+            headerText,
             walletConnectionContent,
             shouldShowEthAccountInHeader,
+            ethAccount,
             ...restProps
         } = this.props;
         const status: string = ethAccount ? 'active' : '';
-
-        const ethAccountText = ethAccount ? `${truncateAddress(ethAccount)}` : 'Not connected';
-        const ethBalanceText = ethBalance ? `${tokenAmountInUnits(ethBalance, ETH_DECIMALS)} ETH` : 'No connected';
-        // If the app is erc20, we need to show the eth account in the header, otherwise, we should the ethBalance
-        const headerText = shouldShowEthAccountInHeader ? ethAccountText : ethBalanceText;
         const header = (
             <WalletConnectionStatusWrapper>
                 <WalletConnectionStatusDotStyled status={status} />
@@ -80,17 +65,3 @@ class WalletConnectionStatus extends React.PureComponent<Props> {
         );
     };
 }
-
-const mapStateToProps = (state: StoreState): StateProps => {
-    return {
-        ethAccount: getEthAccount(state),
-        ethBalance: getEthBalance(state),
-    };
-};
-
-const WalletConnectionStatusContainer = connect(
-    mapStateToProps,
-    {},
-)(WalletConnectionStatus);
-
-export { WalletConnectionStatus, WalletConnectionStatusContainer };

--- a/src/components/account/wallet_weth_balance.tsx
+++ b/src/components/account/wallet_weth_balance.tsx
@@ -30,6 +30,8 @@ interface OwnProps {
     className?: string;
     inDropdown?: boolean;
     theme: Theme;
+    onWethModalOpen?: () => any;
+    onWethModalClose?: () => any;
 }
 
 type Props = OwnProps & StateProps & DispatchProps;
@@ -235,16 +237,23 @@ class WalletWethBalance extends React.PureComponent<Props, State> {
 
     public openModal = (e: any) => {
         e.stopPropagation(); // avoids dropdown closing when used inside one
-
+        const { onWethModalOpen } = this.props;
         this.setState({
             modalIsOpen: true,
         });
+        if (onWethModalOpen) {
+            onWethModalOpen();
+        }
     };
 
     public closeModal = () => {
+        const { onWethModalClose } = this.props;
         this.setState({
             modalIsOpen: false,
         });
+        if (onWethModalClose) {
+            onWethModalClose();
+        }
     };
 }
 

--- a/src/components/common/dropdown.tsx
+++ b/src/components/common/dropdown.tsx
@@ -14,7 +14,6 @@ interface DropdownWrapperBodyProps {
 interface Props extends HTMLAttributes<HTMLDivElement>, DropdownWrapperBodyProps {
     body: React.ReactNode;
     header: React.ReactNode;
-    shouldCloseDropdownBodyOnClick?: boolean;
     shouldCloseDropdownOnClickOutside?: boolean;
 }
 
@@ -80,8 +79,8 @@ export class Dropdown extends React.Component<Props, State> {
     };
 
     private readonly _handleClickOutside = (event: any) => {
+        const { shouldCloseDropdownOnClickOutside = true } = this.props;
         if (this._wrapperRef && !this._wrapperRef.contains(event.target)) {
-            const { shouldCloseDropdownOnClickOutside = true } = this.props;
             if (shouldCloseDropdownOnClickOutside) {
                 this.closeDropdown();
             }
@@ -93,8 +92,8 @@ export class Dropdown extends React.Component<Props, State> {
     };
 
     private readonly _closeDropdownBody = () => {
-        const { shouldCloseDropdownBodyOnClick = true } = this.props;
-        if (shouldCloseDropdownBodyOnClick) {
+        const { shouldCloseDropdownOnClickOutside = true } = this.props;
+        if (shouldCloseDropdownOnClickOutside) {
             this.closeDropdown();
         }
     };

--- a/src/components/erc20/account/wallet_connection_content.tsx
+++ b/src/components/erc20/account/wallet_connection_content.tsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import styled from 'styled-components';
 
 import { getEthAccount } from '../../../store/selectors';
+import { truncateAddress } from '../../../util/number_utils';
 import { StoreState } from '../../../util/types';
 import { WalletConnectionStatusContainer } from '../../account/wallet_connection_status';
 import { CardBase } from '../../common/card_base';
@@ -33,6 +34,7 @@ const DropdownItems = styled(CardBase)`
 class WalletConnectionContent extends React.PureComponent<Props> {
     public render = () => {
         const { ethAccount, ...restProps } = this.props;
+        const ethAccountText = ethAccount ? `${truncateAddress(ethAccount)}` : 'Not connected';
 
         const content = (
             <DropdownItems>
@@ -48,6 +50,8 @@ class WalletConnectionContent extends React.PureComponent<Props> {
             <WalletConnectionStatusContainer
                 walletConnectionContent={content}
                 shouldShowEthAccountInHeader={true}
+                headerText={ethAccountText}
+                ethAccount={ethAccount}
                 {...restProps}
             />
         );

--- a/src/components/erc20/account/wallet_connection_content.tsx
+++ b/src/components/erc20/account/wallet_connection_content.tsx
@@ -49,7 +49,6 @@ class WalletConnectionContent extends React.PureComponent<Props> {
         return (
             <WalletConnectionStatusContainer
                 walletConnectionContent={content}
-                shouldShowEthAccountInHeader={true}
                 headerText={ethAccountText}
                 ethAccount={ethAccount}
                 {...restProps}

--- a/src/components/erc20/common/markets_dropdown.tsx
+++ b/src/components/erc20/common/markets_dropdown.tsx
@@ -35,6 +35,7 @@ type Props = PropsDivElement & PropsToken & DispatchProps;
 interface State {
     selectedFilter: Filter;
     search: string;
+    isUserOnDropdown: boolean;
 }
 
 interface TokenFiltersTabProps {
@@ -247,6 +248,7 @@ class MarketsDropdown extends React.Component<Props, State> {
     public readonly state: State = {
         selectedFilter: marketFilters[0],
         search: '',
+        isUserOnDropdown: false,
     };
 
     private readonly _dropdown = React.createRef<Dropdown>();
@@ -272,7 +274,7 @@ class MarketsDropdown extends React.Component<Props, State> {
 
         const body = (
             <MarketsDropdownBody>
-                <MarketsFilters>
+                <MarketsFilters onMouseOver={this._setUserOnDropdown} onMouseOut={this._removeUserOnDropdown}>
                     <MarketsFiltersLabel>Markets</MarketsFiltersLabel>
                     {this._getTokensFilterTabs()}
                     {this._getSearchField()}
@@ -280,8 +282,23 @@ class MarketsDropdown extends React.Component<Props, State> {
                 <TableWrapper>{this._getMarkets()}</TableWrapper>
             </MarketsDropdownBody>
         );
+        return (
+            <MarketsDropdownWrapper
+                body={body}
+                header={header}
+                ref={this._dropdown}
+                shouldCloseDropdownOnClickOutside={!this.state.isUserOnDropdown}
+                {...restProps}
+            />
+        );
+    };
 
-        return <MarketsDropdownWrapper body={body} header={header} ref={this._dropdown} {...restProps} />;
+    private readonly _setUserOnDropdown = () => {
+        this.setState({ isUserOnDropdown: true });
+    };
+
+    private readonly _removeUserOnDropdown = () => {
+        this.setState({ isUserOnDropdown: false });
     };
 
     private readonly _getTokensFilterTabs = () => {

--- a/src/components/erc721/account/wallet_connection_content.tsx
+++ b/src/components/erc721/account/wallet_connection_content.tsx
@@ -15,15 +15,6 @@ import { WalletConnectionStatusDot } from '../../account/wallet_connections_stat
 import { CardBase } from '../../common/card_base';
 import { DropdownTextItem } from '../../common/dropdown_text_item';
 
-interface OwnProps extends HTMLAttributes<HTMLSpanElement> {}
-
-interface StateProps {
-    ethAccount: string;
-    ethBalance: BigNumber;
-}
-
-type Props = StateProps & OwnProps;
-
 const truncateAddress = (address: string) => {
     return `${address.slice(0, 7)}...${address.slice(address.length - 5)}`;
 };
@@ -82,7 +73,23 @@ const DropdownTextItemStyled = styled(DropdownTextItem)`
     border: none;
 `;
 
-class WalletConnectionContent extends React.PureComponent<Props> {
+interface OwnProps extends HTMLAttributes<HTMLSpanElement> {}
+
+interface StateProps {
+    ethAccount: string;
+    ethBalance: BigNumber;
+}
+
+type Props = StateProps & OwnProps;
+
+interface State {
+    isEthModalOpen: boolean;
+}
+
+class WalletConnectionContent extends React.Component<Props, State> {
+    public readonly state: State = {
+        isEthModalOpen: false,
+    };
     public render = () => {
         const { ethAccount, ethBalance, ...restProps } = this.props;
         const ethAccountText = ethAccount ? `${truncateAddress(ethAccount)}` : 'Not connected';
@@ -97,7 +104,11 @@ class WalletConnectionContent extends React.PureComponent<Props> {
                         {ethAccountText}
                     </WalletAddress>
                 </DropdownHeader>
-                <WalletWethBalanceContainerStyled inDropdown={true} />
+                <WalletWethBalanceContainerStyled
+                    inDropdown={true}
+                    onWethModalOpen={this._ethModalOpen}
+                    onWethModalClose={this._ethModalClose}
+                />
                 <CopyToClipboard text={ethAccount ? ethAccount : ''}>
                     <DropdownTextItemStyled text="Copy Address" />
                 </CopyToClipboard>
@@ -108,12 +119,20 @@ class WalletConnectionContent extends React.PureComponent<Props> {
         return (
             <WalletConnectionStatusContainer
                 walletConnectionContent={content}
-                shouldShowEthAccountInHeader={false}
+                shouldCloseDropdownOnClickOutside={!this.state.isEthModalOpen}
                 headerText={ethBalanceText}
                 ethAccount={ethAccount}
                 {...restProps}
             />
         );
+    };
+
+    private readonly _ethModalOpen = () => {
+        this.setState({ isEthModalOpen: true });
+    };
+
+    private readonly _ethModalClose = () => {
+        this.setState({ isEthModalOpen: false });
     };
 }
 

--- a/src/components/erc721/account/wallet_connection_content.tsx
+++ b/src/components/erc721/account/wallet_connection_content.tsx
@@ -1,10 +1,13 @@
+import { BigNumber } from '0x.js';
 import React, { HTMLAttributes } from 'react';
 import CopyToClipboard from 'react-copy-to-clipboard';
 import { connect } from 'react-redux';
 import styled from 'styled-components';
 
-import { getEthAccount } from '../../../store/selectors';
+import { ETH_DECIMALS } from '../../../common/constants';
+import { getEthAccount, getEthBalance } from '../../../store/selectors';
 import { themeDimensions } from '../../../themes/commons';
+import { tokenAmountInUnits } from '../../../util/tokens';
 import { StoreState } from '../../../util/types';
 import { WalletWethBalanceContainer } from '../../account';
 import { WalletConnectionStatusContainer } from '../../account/wallet_connection_status';
@@ -16,6 +19,7 @@ interface OwnProps extends HTMLAttributes<HTMLSpanElement> {}
 
 interface StateProps {
     ethAccount: string;
+    ethBalance: BigNumber;
 }
 
 type Props = StateProps & OwnProps;
@@ -80,10 +84,10 @@ const DropdownTextItemStyled = styled(DropdownTextItem)`
 
 class WalletConnectionContent extends React.PureComponent<Props> {
     public render = () => {
-        const { ethAccount, ...restProps } = this.props;
+        const { ethAccount, ethBalance, ...restProps } = this.props;
         const ethAccountText = ethAccount ? `${truncateAddress(ethAccount)}` : 'Not connected';
         const status: string = ethAccount ? 'active' : '';
-
+        const ethBalanceText = ethBalance ? `${tokenAmountInUnits(ethBalance, ETH_DECIMALS)} ETH` : 'No connected';
         const content = (
             <WalletConnectionWrapper>
                 <DropdownHeader>
@@ -105,6 +109,8 @@ class WalletConnectionContent extends React.PureComponent<Props> {
             <WalletConnectionStatusContainer
                 walletConnectionContent={content}
                 shouldShowEthAccountInHeader={false}
+                headerText={ethBalanceText}
+                ethAccount={ethAccount}
                 {...restProps}
             />
         );
@@ -114,6 +120,7 @@ class WalletConnectionContent extends React.PureComponent<Props> {
 const mapStateToProps = (state: StoreState): StateProps => {
     return {
         ethAccount: getEthAccount(state),
+        ethBalance: getEthBalance(state),
     };
 };
 

--- a/src/components/notifications/notifications_dropdown.tsx
+++ b/src/components/notifications/notifications_dropdown.tsx
@@ -109,7 +109,6 @@ class NotificationsDropdown extends React.Component<Props, {}> {
                 header={header}
                 horizontalPosition={DropdownPositions.Right}
                 onClick={onMarkNotificationsAsRead}
-                shouldCloseDropdownBodyOnClick={false}
                 {...restProps}
             />
         );


### PR DESCRIPTION
Closes #497 

## Description

Before this PR, the user needed to press the dropdown in the toolbar to close it, now the dropdown should close everytime the user clicks outside the dropdown (but only if the wETH converter is NOT open)

Also I'd made a little refactor of the `WalletConnectionStatusContainer` (see first commit). 
Now that component does not have status and is not responsible for set the `headerText`, it should be defined from the different `WalletConnectionContent` (ERC20 and ERC721)