### PR TITLE
Add ThemeProperties.cardImageBackgroundColor.

### DIFF
--- a/src/components/erc721/collectibles/collectible_card.tsx
+++ b/src/components/erc721/collectibles/collectible_card.tsx
@@ -35,7 +35,7 @@ const CollectibleCardWrapper = styled(Link)`
 
 const ImageWrapper = styled.div<{ color: string; image: string }>`
     background-clip: padding-box;
-    background-color: ${props => props.color || props.theme.componentsTheme.cardBackgroundColor};
+    background-color: ${props => props.color || props.theme.componentsTheme.cardImageBackgroundColor};
     background-image: url('${props => props.image}');
     background-position: 50% 50%;
     background-size: contain;

--- a/src/themes/commons.ts
+++ b/src/themes/commons.ts
@@ -20,6 +20,7 @@ export interface ThemeProperties {
     buttonSellBackgroundColor: string;
     buttonTertiaryBackgroundColor: string;
     buttonTextColor: string;
+    cardImageBackgroundColor: string;
     cardBackgroundColor: string;
     cardBorderColor: string;
     cardTitleColor: string;

--- a/src/themes/dark_theme.ts
+++ b/src/themes/dark_theme.ts
@@ -44,6 +44,7 @@ const darkThemeColors: ThemeProperties = {
     buttonSellBackgroundColor: '#FF6534',
     buttonTertiaryBackgroundColor: '#F6851B',
     buttonTextColor: '#fff',
+    cardImageBackgroundColor: '#EBF0F5',
     cardBackgroundColor: '#202123',
     cardBorderColor: '#000',
     cardTitleColor: '#fff',

--- a/src/themes/default_theme.ts
+++ b/src/themes/default_theme.ts
@@ -43,6 +43,7 @@ const lightThemeColors: ThemeProperties = {
     buttonSellBackgroundColor: '#FF6534',
     buttonTertiaryBackgroundColor: '#F6851B',
     buttonTextColor: '#fff',
+    cardImageBackgroundColor: '#EBF0F5',
     cardBackgroundColor: '#fff',
     cardBorderColor: '#dedede',
     cardTitleColor: '#000',


### PR DESCRIPTION
Closes #445.

### Includes

- Adds the property `cardImageBackgroundColor` to `ThemeProperties`.
- Use in `collectible_card.tsx` if no color was provided.

### Screens

_Notice the gray inside the card._

![collectible_image_bacground_color](https://user-images.githubusercontent.com/4421917/58725538-c3466300-83b5-11e9-9f87-b5fb9d48cee2.png)

To generate the screenshot I used an asset image taken from opensea+Axie (opensea doesn't set a background color for Axie's assets), and replaced `image` with the corresponding URL and set `color` as `''`  it in `collectibles_metadata_sources/mocked.ts`.

