### PR TITLE
Estimate wait times are too long

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -55,7 +55,9 @@ export const ETH_GAS_STATION_API_BASE_URL = 'https://ethgasstation.info';
 
 export const GWEI_IN_WEI = new BigNumber(1000000000);
 
-export const ONE_MINUTE_MS = 1000 * 60;
+export const ONE_SECOND_MS = 1000;
+
+export const ONE_MINUTE_MS = ONE_SECOND_MS * 60;
 
 export const DEFAULT_GAS_PRICE = GWEI_IN_WEI.multipliedBy(6);
 

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -55,9 +55,7 @@ export const ETH_GAS_STATION_API_BASE_URL = 'https://ethgasstation.info';
 
 export const GWEI_IN_WEI = new BigNumber(1000000000);
 
-export const ONE_SECOND_MS = 1000;
-
-export const ONE_MINUTE_MS = ONE_SECOND_MS * 60;
+export const ONE_MINUTE_MS = 1000 * 60;
 
 export const DEFAULT_GAS_PRICE = GWEI_IN_WEI.multipliedBy(6);
 

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -51,8 +51,6 @@ export const UPDATE_ETHER_PRICE_INTERVAL: number = process.env.REACT_APP_UPDATE_
 export const NOTIFICATIONS_LIMIT: number =
     Number.parseInt(process.env.REACT_APP_NOTIFICATIONS_LIMIT as string, 10) || 20;
 
-export const ETH_GAS_STATION_API_BASE_URL = 'https://ethgasstation.info';
-
 export const GWEI_IN_WEI = new BigNumber(1000000000);
 
 export const ONE_MINUTE_MS = 1000 * 60;

--- a/src/services/gas_price_estimation.ts
+++ b/src/services/gas_price_estimation.ts
@@ -18,7 +18,7 @@ interface EthGasStationResult {
     safeLow: number;
 }
 
-const logger = getLogger('Gas Estimation from ethgasAPI::gas_price_estimation.ts');
+const logger = getLogger('gas_price_estimation');
 
 const ETH_GAS_STATION_API_BASE_URL = 'https://ethgasstation.info';
 
@@ -31,14 +31,12 @@ export const getGasEstimationInfoAsync = async (): Promise<GasInfo> => {
         fetchedAmount = undefined;
     }
 
-    logger.info(fetchedAmount);
-
-    return (
-        fetchedAmount || {
-            gasPriceInWei: DEFAULT_GAS_PRICE,
-            estimatedTimeMs: DEFAULT_ESTIMATED_TRANSACTION_TIME_MS,
-        }
-    );
+    const info = fetchedAmount || {
+        gasPriceInWei: DEFAULT_GAS_PRICE,
+        estimatedTimeMs: DEFAULT_ESTIMATED_TRANSACTION_TIME_MS,
+    };
+    logger.info(info);
+    return info;
 };
 
 const fetchFastAmountInWeiAsync = async (): Promise<GasInfo> => {

--- a/src/services/gas_price_estimation.ts
+++ b/src/services/gas_price_estimation.ts
@@ -1,4 +1,5 @@
 import { BigNumber } from '0x.js';
+import { RateLimit } from 'async-sema';
 
 import {
     DEFAULT_ESTIMATED_TRANSACTION_TIME_MS,
@@ -6,6 +7,7 @@ import {
     ETH_GAS_STATION_API_BASE_URL,
     GWEI_IN_WEI,
 } from '../common/constants';
+import { getLogger } from '../util/logger';
 import { GasInfo } from '../util/types';
 
 interface EthGasStationResult {
@@ -22,20 +24,28 @@ interface EthGasStationResult {
     safeLow: number;
 }
 
-let fetchedAmount: GasInfo | undefined;
+const logger = getLogger('Gas Estimation from ethgasAPI::gas_price_estimation.ts');
+
 export const getGasEstimationInfoAsync = async (): Promise<GasInfo> => {
+    let fetchedAmount: GasInfo | undefined;
+
+    const lim = RateLimit(1);
+
     try {
+        await lim();
         fetchedAmount = await fetchFastAmountInWeiAsync();
-        return (
-            fetchedAmount || {
-                gasPriceInWei: DEFAULT_GAS_PRICE,
-                estimatedTimeMs: DEFAULT_ESTIMATED_TRANSACTION_TIME_MS,
-            }
-        );
     } catch (e) {
         fetchedAmount = undefined;
-        return Promise.reject('Could not get gas price');
     }
+
+    logger.info(fetchedAmount);
+
+    return (
+        fetchedAmount || {
+            gasPriceInWei: DEFAULT_GAS_PRICE,
+            estimatedTimeMs: DEFAULT_ESTIMATED_TRANSACTION_TIME_MS,
+        }
+    );
 };
 
 const fetchFastAmountInWeiAsync = async (): Promise<GasInfo> => {

--- a/src/services/gas_price_estimation.ts
+++ b/src/services/gas_price_estimation.ts
@@ -1,12 +1,6 @@
 import { BigNumber } from '0x.js';
-import { RateLimit } from 'async-sema';
 
-import {
-    DEFAULT_ESTIMATED_TRANSACTION_TIME_MS,
-    DEFAULT_GAS_PRICE,
-    ETH_GAS_STATION_API_BASE_URL,
-    GWEI_IN_WEI,
-} from '../common/constants';
+import { DEFAULT_ESTIMATED_TRANSACTION_TIME_MS, DEFAULT_GAS_PRICE, GWEI_IN_WEI } from '../common/constants';
 import { getLogger } from '../util/logger';
 import { GasInfo } from '../util/types';
 
@@ -26,13 +20,12 @@ interface EthGasStationResult {
 
 const logger = getLogger('Gas Estimation from ethgasAPI::gas_price_estimation.ts');
 
+const ETH_GAS_STATION_API_BASE_URL = 'https://ethgasstation.info';
+
 export const getGasEstimationInfoAsync = async (): Promise<GasInfo> => {
     let fetchedAmount: GasInfo | undefined;
 
-    const lim = RateLimit(1);
-
     try {
-        await lim();
         fetchedAmount = await fetchFastAmountInWeiAsync();
     } catch (e) {
         fetchedAmount = undefined;


### PR DESCRIPTION
Connects #524 

Currently, the estimate of a transaction is obtained from gas station. Gas station only works for the mainnet, so in the case of being in an environment like kovan, rinkeby or local ganache the estimate will not be reliable. If an exception happens (throttled request, for example) default/hardcoded values will be returned.

Right now the [DEFAULT_ESTIMATED_TRANSACTION_TIME_MS](https://github.com/0xProject/0x-monorepo/blob/14f3d20772ba8830d414140382be8006fe5e2147/packages/instant/src/constants.ts#L26) constant is the same as in other projects like Instant.