### PR TITLE
Orderbook doesn't show orders until wallet connects to Mainet

### DIFF
--- a/src/services/orders.ts
+++ b/src/services/orders.ts
@@ -31,6 +31,11 @@ export const getAllOrdersAsUIOrders = async (baseToken: Token, quoteToken: Token
     }
 };
 
+export const getAllOrdersAsUIOrdersWithoutOrdersInfo = async (baseToken: Token, quoteToken: Token) => {
+    const orders: SignedOrder[] = await getAllOrders(baseToken, quoteToken);
+    return ordersToUIOrders(orders, baseToken);
+};
+
 export const getUserOrders = (baseToken: Token, quoteToken: Token, ethAccount: string) => {
     const relayer = getRelayer();
     const baseTokenAssetData = assetDataUtils.encodeERC20AssetData(baseToken.address);


### PR DESCRIPTION
Connects to #520 

I think there are two problems in the issue #520 :
- One is due to the use of a constant as a network id, it has to be solved in this issue #523 
- The other is because the application was trying to instantiate the web3Wrapper without being injected web3

This PR solves the second problem...

To test this problem it is necessary to set the MAINNET_ID constant in the network that needs to be tested and is configured in the relayer, check this [line](https://github.com/0xProject/0x-launch-kit-frontend/blob/development/src/store/blockchain/actions.ts#L477) related to this situation. 