### PR TITLE
Some minor improvements related to network detection

### DIFF
--- a/src/services/collectibles_metadata_gateway.ts
+++ b/src/services/collectibles_metadata_gateway.ts
@@ -19,7 +19,7 @@ export class CollectiblesMetadataGateway {
         this._source = source;
     }
 
-    public fetchAllCollectibles = async (userAddress: string): Promise<Collectible[]> => {
+    public fetchAllCollectibles = async (userAddress?: string): Promise<Collectible[]> => {
         const knownTokens = getKnownTokens();
 
         const wethAddress = knownTokens.getWethToken().address;
@@ -40,17 +40,20 @@ export class CollectiblesMetadataGateway {
         }, {});
 
         // Step 2: Get all the user's collectibles and add the order
-        const userCollectibles = await this._source.fetchAllUserCollectiblesAsync(userAddress);
-        const collectiblesWithOrders: Collectible[] = userCollectibles.map(collectible => {
-            if (tokenIdToOrder[collectible.tokenId]) {
-                return {
-                    ...collectible,
-                    order: tokenIdToOrder[collectible.tokenId],
-                };
-            }
+        let collectiblesWithOrders: Collectible[] = [];
+        if (userAddress) {
+            const userCollectibles = await this._source.fetchAllUserCollectiblesAsync(userAddress);
+            collectiblesWithOrders = userCollectibles.map(collectible => {
+                if (tokenIdToOrder[collectible.tokenId]) {
+                    return {
+                        ...collectible,
+                        order: tokenIdToOrder[collectible.tokenId],
+                    };
+                }
 
-            return collectible;
-        });
+                return collectible;
+            });
+        }
 
         // Step 3: Get collectibles that are not from the user
         let collectiblesFetched: any[] = [];

--- a/src/store/blockchain/actions.ts
+++ b/src/store/blockchain/actions.ts
@@ -1,3 +1,4 @@
+// tslint:disable:max-file-line-count
 import { BigNumber, MetamaskSubprovider, signatureUtils } from '0x.js';
 import { createAction } from 'typesafe-actions';
 
@@ -281,8 +282,10 @@ export const initWallet: ThunkCreator<Promise<any>> = () => {
             await dispatch(initWalletBeginCommon());
 
             if (currentMarketPlace === MARKETPLACES.ERC20) {
+                // tslint:disable-next-line:no-floating-promises
                 dispatch(initWalletERC20());
             } else {
+                // tslint:disable-next-line:no-floating-promises
                 dispatch(initWalletERC721());
             }
         } catch (error) {
@@ -320,9 +323,10 @@ const initWalletBeginCommon: ThunkCreator<Promise<any>> = () => {
                     userOrders: [],
                 }),
             );
-
+            // tslint:disable-next-line:no-floating-promises
             dispatch(updateGasInfo());
 
+            // tslint:disable-next-line:no-floating-promises
             dispatch(updateMarketPriceEther());
 
             const networkId = await web3Wrapper.getNetworkIdAsync();
@@ -337,12 +341,15 @@ const initWalletERC20: ThunkCreator<Promise<any>> = () => {
     return async (dispatch, getState, { getWeb3Wrapper }) => {
         const web3Wrapper = await getWeb3Wrapper();
         if (!web3Wrapper) {
+            // tslint:disable-next-line:no-floating-promises
             dispatch(initializeAppNoMetamaskOrLocked());
+
+            // tslint:disable-next-line:no-floating-promises
             dispatch(getOrderBook());
         } else {
             const state = getState();
             const knownTokens = getKnownTokens();
-            const ethAccount = await getEthAccount(state);
+            const ethAccount = getEthAccount(state);
 
             const tokenBalances = await Promise.all(
                 knownTokens.getTokens().map(token => tokenToTokenBalance(token, ethAccount)),
@@ -354,11 +361,13 @@ const initWalletERC20: ThunkCreator<Promise<any>> = () => {
             dispatch(setMarketTokens({ baseToken, quoteToken }));
             dispatch(setTokenBalances(tokenBalances));
 
+            // tslint:disable-next-line:no-floating-promises
             dispatch(getOrderbookAndUserOrders());
 
             try {
                 await dispatch(fetchMarkets());
                 // For executing this method (setConnectedUserNotifications) is necessary that the setMarkets method is already dispatched, otherwise it wont work (redux-thunk problem), so it's need to be dispatched here
+                // tslint:disable-next-line:no-floating-promises
                 dispatch(setConnectedUserNotifications(ethAccount));
             } catch (error) {
                 // Relayer error
@@ -373,10 +382,14 @@ const initWalletERC721: ThunkCreator<Promise<any>> = () => {
         const web3Wrapper = await getWeb3Wrapper();
         if (web3Wrapper) {
             const state = getState();
-            const ethAccount = await getEthAccount(state);
+            const ethAccount = getEthAccount(state);
+            // tslint:disable-next-line:no-floating-promises
             dispatch(getAllCollectibles(ethAccount));
         } else {
+            // tslint:disable-next-line:no-floating-promises
             dispatch(initializeAppNoMetamaskOrLocked());
+
+            // tslint:disable-next-line:no-floating-promises
             dispatch(getAllCollectibles());
         }
     };
@@ -492,15 +505,19 @@ export const initializeAppNoMetamaskOrLocked: ThunkCreator = () => {
             }),
         );
 
+        // tslint:disable-next-line:no-floating-promises
         dispatch(setMarketTokens({ baseToken, quoteToken }));
 
         const currentMarketPlace = getCurrentMarketPlace(state);
         if (currentMarketPlace === MARKETPLACES.ERC20) {
+            // tslint:disable-next-line:no-floating-promises
             dispatch(getOrderBook());
         } else {
+            // tslint:disable-next-line:no-floating-promises
             dispatch(getAllCollectibles());
         }
 
+        // tslint:disable-next-line:no-floating-promises
         dispatch(updateMarketPriceEther());
     };
 };

--- a/src/store/blockchain/actions.ts
+++ b/src/store/blockchain/actions.ts
@@ -512,6 +512,9 @@ export const initializeAppNoMetamaskOrLocked: ThunkCreator = () => {
         if (currentMarketPlace === MARKETPLACES.ERC20) {
             // tslint:disable-next-line:no-floating-promises
             dispatch(getOrderBook());
+
+            // tslint:disable-next-line:no-floating-promises
+            await dispatch(fetchMarkets());
         } else {
             // tslint:disable-next-line:no-floating-promises
             dispatch(getAllCollectibles());

--- a/src/store/blockchain/actions.ts
+++ b/src/store/blockchain/actions.ts
@@ -272,101 +272,110 @@ export const setConnectedUserNotifications: ThunkCreator<Promise<any>> = (ethAcc
 };
 
 export const initWallet: ThunkCreator<Promise<any>> = () => {
-    return async (dispatch, getState, { initializeWeb3Wrapper }) => {
+    return async (dispatch, getState) => {
         dispatch(setWeb3State(Web3State.Loading));
-        const web3Wrapper = await initializeWeb3Wrapper();
         const state = getState();
         const currentMarketPlace = getCurrentMarketPlace(state);
-        if (!web3Wrapper) {
+
+        try {
+            await dispatch(initWalletBeginCommon());
+
             if (currentMarketPlace === MARKETPLACES.ERC20) {
-                initializeAppNoMetamaskOrLocked();
+                dispatch(initWalletERC20());
+            } else {
+                dispatch(initWalletERC721());
             }
-        } else {
-            try {
-                const networkId = await web3Wrapper.getNetworkIdAsync();
+        } catch (error) {
+            // Web3Error
+            logger.error('There was an error when initializing the wallet', error);
+            dispatch(setWeb3State(Web3State.Error));
+        }
+    };
+};
 
-                if (networkId !== NETWORK_ID) {
-                    throw new Error('Wrong network id selected');
-                }
+const initWalletBeginCommon: ThunkCreator<Promise<any>> = () => {
+    return async (dispatch, getState, { initializeWeb3Wrapper }) => {
+        const web3Wrapper = await initializeWeb3Wrapper();
 
-                const [ethAccount] = await web3Wrapper.getAvailableAddressesAsync();
+        if (web3Wrapper) {
+            const [ethAccount] = await web3Wrapper.getAvailableAddressesAsync();
+            const knownTokens = getKnownTokens();
+            const wethToken = knownTokens.getWethToken();
+            const wethTokenBalance = await tokenToTokenBalance(wethToken, ethAccount);
+            const ethBalance = await web3Wrapper.getBalanceInWeiAsync(ethAccount);
 
-                const knownTokens = getKnownTokens();
+            await dispatch(
+                initializeBlockchainData({
+                    ethAccount,
+                    web3State: Web3State.Done,
+                    ethBalance,
+                    wethTokenBalance,
+                    tokenBalances: [],
+                }),
+            );
 
-                const wethToken = knownTokens.getWethToken();
+            dispatch(
+                initializeRelayerData({
+                    orders: [],
+                    userOrders: [],
+                }),
+            );
 
-                const wethTokenBalance = await tokenToTokenBalance(wethToken, ethAccount);
+            dispatch(updateGasInfo());
 
-                const ethBalance = await web3Wrapper.getBalanceInWeiAsync(ethAccount);
+            dispatch(updateMarketPriceEther());
 
-                dispatch(
-                    initializeBlockchainData({
-                        ethAccount,
-                        web3State: Web3State.Done,
-                        ethBalance,
-                        wethTokenBalance,
-                        tokenBalances: [],
-                    }),
-                );
-                dispatch(
-                    initializeRelayerData({
-                        orders: [],
-                        userOrders: [],
-                    }),
-                );
-                // tslint:disable-next-line:no-floating-promises
-                dispatch(updateGasInfo());
-                // tslint:disable-next-line:no-floating-promises
-                dispatch(updateMarketPriceEther());
-                // Inits wallet based on the current app
-                if (currentMarketPlace === MARKETPLACES.ERC20) {
-                    // tslint:disable-next-line:no-floating-promises
-                    dispatch(initWalletERC20(ethAccount));
-                } else {
-                    // tslint:disable-next-line:no-floating-promises
-                    dispatch(initWalletERC721(ethAccount));
-                }
-            } catch (error) {
-                // Web3Error
-                logger.error('There was an error fetching the account or networkId from web3', error);
+            const networkId = await web3Wrapper.getNetworkIdAsync();
+            if (networkId !== NETWORK_ID) {
                 dispatch(setWeb3State(Web3State.Error));
             }
         }
     };
 };
 
-const initWalletERC20: ThunkCreator<Promise<any>> = (ethAccount: string) => {
-    return async (dispatch, getState) => {
-        const state = getState();
-        const knownTokens = getKnownTokens();
+const initWalletERC20: ThunkCreator<Promise<any>> = () => {
+    return async (dispatch, getState, { getWeb3Wrapper }) => {
+        const web3Wrapper = await getWeb3Wrapper();
+        if (!web3Wrapper) {
+            dispatch(getOrderBook());
+            dispatch(initializeAppNoMetamaskOrLocked());
+        } else {
+            const state = getState();
+            const knownTokens = getKnownTokens();
+            const ethAccount = await getEthAccount(state);
 
-        const tokenBalances = await Promise.all(
-            knownTokens.getTokens().map(token => tokenToTokenBalance(token, ethAccount)),
-        );
-        const currencyPair = getCurrencyPair(state);
-        const baseToken = knownTokens.getTokenBySymbol(currencyPair.base);
-        const quoteToken = knownTokens.getTokenBySymbol(currencyPair.quote);
+            const tokenBalances = await Promise.all(
+                knownTokens.getTokens().map(token => tokenToTokenBalance(token, ethAccount)),
+            );
+            const currencyPair = getCurrencyPair(state);
+            const baseToken = knownTokens.getTokenBySymbol(currencyPair.base);
+            const quoteToken = knownTokens.getTokenBySymbol(currencyPair.quote);
 
-        dispatch(setMarketTokens({ baseToken, quoteToken }));
-        // tslint:disable-next-line:no-floating-promises
-        dispatch(getOrderbookAndUserOrders());
-        dispatch(setTokenBalances(tokenBalances));
-        try {
-            await dispatch(fetchMarkets());
-            // For executing this method (setConnectedUserNotifications) is necessary that the setMarkets method is already dispatched, otherwise it wont work (redux-thunk problem), so it's need to be dispatched here
-            // tslint:disable-next-line:no-floating-promises
-            dispatch(setConnectedUserNotifications(ethAccount));
-        } catch (error) {
-            // Relayer error
-            logger.error('The fetch orders from the relayer failed', error);
+            dispatch(setMarketTokens({ baseToken, quoteToken }));
+            dispatch(setTokenBalances(tokenBalances));
+
+            dispatch(getOrderbookAndUserOrders());
+
+            try {
+                await dispatch(fetchMarkets());
+                // For executing this method (setConnectedUserNotifications) is necessary that the setMarkets method is already dispatched, otherwise it wont work (redux-thunk problem), so it's need to be dispatched here
+                dispatch(setConnectedUserNotifications(ethAccount));
+            } catch (error) {
+                // Relayer error
+                logger.error('The fetch markets from the relayer failed', error);
+            }
         }
     };
 };
 
-const initWalletERC721: ThunkCreator<Promise<any>> = (ethAccount: string) => {
-    return async dispatch => {
-        // tslint:disable-next-line:no-floating-promises
-        dispatch(getAllCollectibles(ethAccount));
+const initWalletERC721: ThunkCreator<Promise<any>> = () => {
+    return async (dispatch, getState, { getWeb3Wrapper }) => {
+        const web3Wrapper = await getWeb3Wrapper();
+        if (web3Wrapper) {
+            const state = getState();
+            const ethAccount = await getEthAccount(state);
+            dispatch(getAllCollectibles(ethAccount));
+        }
     };
 };
 
@@ -482,10 +491,8 @@ export const initializeAppNoMetamaskOrLocked: ThunkCreator = () => {
 
         dispatch(setMarketTokens({ baseToken, quoteToken }));
 
-        // tslint:disable-next-line:no-floating-promises
         dispatch(getOrderBook());
 
-        // tslint:disable-next-line:no-floating-promises
         dispatch(updateMarketPriceEther());
     };
 };

--- a/src/store/blockchain/actions.ts
+++ b/src/store/blockchain/actions.ts
@@ -337,8 +337,8 @@ const initWalletERC20: ThunkCreator<Promise<any>> = () => {
     return async (dispatch, getState, { getWeb3Wrapper }) => {
         const web3Wrapper = await getWeb3Wrapper();
         if (!web3Wrapper) {
-            dispatch(getOrderBook());
             dispatch(initializeAppNoMetamaskOrLocked());
+            dispatch(getOrderBook());
         } else {
             const state = getState();
             const knownTokens = getKnownTokens();
@@ -375,6 +375,9 @@ const initWalletERC721: ThunkCreator<Promise<any>> = () => {
             const state = getState();
             const ethAccount = await getEthAccount(state);
             dispatch(getAllCollectibles(ethAccount));
+        } else {
+            dispatch(initializeAppNoMetamaskOrLocked());
+            dispatch(getAllCollectibles());
         }
     };
 };
@@ -491,7 +494,12 @@ export const initializeAppNoMetamaskOrLocked: ThunkCreator = () => {
 
         dispatch(setMarketTokens({ baseToken, quoteToken }));
 
-        dispatch(getOrderBook());
+        const currentMarketPlace = getCurrentMarketPlace(state);
+        if (currentMarketPlace === MARKETPLACES.ERC20) {
+            dispatch(getOrderBook());
+        } else {
+            dispatch(getAllCollectibles());
+        }
 
         dispatch(updateMarketPriceEther());
     };

--- a/src/store/relayer/actions.ts
+++ b/src/store/relayer/actions.ts
@@ -49,9 +49,9 @@ export const getAllOrders: ThunkCreator = () => {
         const web3State = getWeb3State(state) as Web3State;
         try {
             let uiOrders: UIOrder[] = [];
-            const isWeb3NotInstalled = [Web3State.Locked, Web3State.NotInstalled].includes(web3State);
+            const isWeb3NotDoneState = [Web3State.Locked, Web3State.NotInstalled, Web3State.Error].includes(web3State);
             // tslint:disable-next-line:prefer-conditional-expression
-            if (isWeb3NotInstalled) {
+            if (isWeb3NotDoneState) {
                 uiOrders = await getAllOrdersAsUIOrdersWithoutOrdersInfo(baseToken, quoteToken);
             } else {
                 uiOrders = await getAllOrdersAsUIOrders(baseToken, quoteToken);
@@ -69,9 +69,15 @@ export const getUserOrders: ThunkCreator = () => {
         const baseToken = getBaseToken(state) as Token;
         const quoteToken = getQuoteToken(state) as Token;
         const ethAccount = getEthAccount(state);
+        const web3State = getWeb3State(state) as Web3State;
+
         try {
-            const myUIOrders = await getUserOrdersAsUIOrders(baseToken, quoteToken, ethAccount);
-            dispatch(setUserOrders(myUIOrders));
+            const isWeb3DoneState = web3State === Web3State.Done;
+            // tslint:disable-next-line:prefer-conditional-expression
+            if (isWeb3DoneState) {
+                const myUIOrders = await getUserOrdersAsUIOrders(baseToken, quoteToken, ethAccount);
+                dispatch(setUserOrders(myUIOrders));
+            }
         } catch (err) {
             logger.error(`getUserOrders: fetch orders from the relayer failed.`, err);
         }

--- a/src/store/selectors.ts
+++ b/src/store/selectors.ts
@@ -89,6 +89,7 @@ export const getOpenOrders = createSelector(
     (orders, web3State) => {
         switch (web3State) {
             case Web3State.NotInstalled:
+            case Web3State.Error:
             case Web3State.Locked: {
                 return orders;
             }


### PR DESCRIPTION
Closes #520.

### Includes 

- Change how init wallet is initialized
- Show orders when network id is wrong for erc20
- Show collectibles from relayer when metamask is not connected for erc721
- Fill the erc20 markets dropdown even if MetaMask is locked, or connected to the wrong network.