### PR TITLE
Broken dropdown If one token is not supported by the backend 

### DIFF
--- a/src/store/market/actions.ts
+++ b/src/store/market/actions.ts
@@ -72,21 +72,33 @@ export const fetchMarkets: ThunkCreator = () => {
         const knownTokens = getKnownTokens();
         const relayer = getRelayer();
 
-        const markets = await Promise.all(
-            availableMarkets.map(async market => {
-                const baseToken = knownTokens.getTokenBySymbol(market.base);
-                const quoteToken = knownTokens.getTokenBySymbol(market.quote);
+        let markets: any[] = await Promise.all(
+            availableMarkets.map(async availableMarket => {
+                try {
+                    const baseToken = knownTokens.getTokenBySymbol(availableMarket.base);
+                    const quoteToken = knownTokens.getTokenBySymbol(availableMarket.quote);
 
-                const price = await relayer.getCurrencyPairPriceAsync(baseToken, quoteToken);
+                    const price = await relayer.getCurrencyPairPriceAsync(baseToken, quoteToken);
 
-                return {
-                    currencyPair: market,
-                    price,
-                };
+                    return {
+                        currencyPair: availableMarket,
+                        price,
+                    };
+                } catch (err) {
+                    return null;
+                }
             }),
         );
 
-        dispatch(setMarkets(markets));
+        markets = markets.filter(
+            (value: any): Market => {
+                return value && value.currencyPair;
+            },
+        );
+
+        if (markets && markets.length > 0) {
+            dispatch(setMarkets(markets));
+        }
         return markets;
     };
 };

--- a/src/store/market/actions.ts
+++ b/src/store/market/actions.ts
@@ -8,8 +8,11 @@ import { availableMarkets } from '../../common/markets';
 import { getMarketPriceEther } from '../../services/markets';
 import { getRelayer } from '../../services/relayer';
 import { getKnownTokens } from '../../util/known_tokens';
+import { getLogger } from '../../util/logger';
 import { CurrencyPair, Market, StoreState, ThunkCreator, Token } from '../../util/types';
 import { getOrderbookAndUserOrders } from '../actions';
+
+const logger = getLogger('Market::Actions');
 
 export const setMarketTokens = createAction('market/MARKET_TOKENS_set', resolve => {
     return ({ baseToken, quoteToken }: { baseToken: Token; quoteToken: Token }) => resolve({ baseToken, quoteToken });
@@ -85,6 +88,9 @@ export const fetchMarkets: ThunkCreator = () => {
                         price,
                     };
                 } catch (err) {
+                    logger.error(
+                        `Failed to get price of currency pair ${availableMarket.base}/${availableMarket.quote}`,
+                    );
                     return null;
                 }
             }),

--- a/src/util/known_tokens.ts
+++ b/src/util/known_tokens.ts
@@ -1,9 +1,12 @@
 import { assetDataUtils, ExchangeFillEventArgs, LogWithDecodedArgs } from '0x.js';
 
 import { KNOWN_TOKENS_META_DATA, TokenMetaData } from '../common/tokens_meta_data';
+import { getLogger } from '../util/logger';
 
 import { getWethTokenFromTokensMetaDataByNetworkId, mapTokensMetaDataToTokenByNetworkId } from './token_meta_data';
 import { Token, TokenSymbol } from './types';
+
+const logger = getLogger('Tokens::known_tokens .ts');
 
 export class KnownTokens {
     private readonly _tokens: Token[] = [];
@@ -21,7 +24,9 @@ export class KnownTokens {
             if (symbolInLowerCaseScore === TokenSymbol.Weth) {
                 return this.getWethToken();
             }
-            throw new Error(`Token with symbol ${symbol} not found in known tokens`);
+            const errorMessage = `Token with symbol ${symbol} not found in known tokens`;
+            logger.log(errorMessage);
+            throw new Error(errorMessage);
         }
         return token;
     };


### PR DESCRIPTION
Closes #515

### Includes 
- Catch get token or price the fetch error an log it at the corresponding level (thunk) so it doesn't reach the UI component. Also the corresponding market will be ommited from the collection/array.
- Log error when a token symbol doesn't exist

Console log error image:
![Screenshot_20190614_182311](https://user-images.githubusercontent.com/1144028/59538840-7e501f80-8ed1-11e9-9c12-7b3d35490aaa.png)

### How to reproduce the bug

Based on [this comment](https://github.com/0xProject/0x-launch-kit-frontend/issues/515#issuecomment-502764993)

1. Set the following values in the `.env` file:
```
REACT_APP_RELAYER_URL='https://api.kovan.radarrelay.com/0x/v2'
REACT_APP_NETWORK_ID=42
```
2. Open the file `src/common/tokens_meta_data.ts` and modifle line `44` so that the address is wrong (for example, copy the value from the `Network.Ganache`).
