### PR TITLE
Disable conversion button while the transaction is running

### DIFF
--- a/src/components/account/wallet_weth_balance.tsx
+++ b/src/components/account/wallet_weth_balance.tsx
@@ -4,10 +4,16 @@ import { connect } from 'react-redux';
 import styled, { withTheme } from 'styled-components';
 
 import { startWrapEtherSteps } from '../../store/actions';
-import { getEthBalance, getEthInUsd, getWeb3State, getWethBalance } from '../../store/selectors';
+import {
+    getConvertBalanceState,
+    getEthBalance,
+    getEthInUsd,
+    getWeb3State,
+    getWethBalance,
+} from '../../store/selectors';
 import { Theme, themeDimensions } from '../../themes/commons';
 import { tokenAmountInUnits } from '../../util/tokens';
-import { StoreState, Web3State } from '../../util/types';
+import { ConvertBalanceState, StoreState, Web3State } from '../../util/types';
 import { Card } from '../common/card';
 import { ArrowUpDownIcon } from '../common/icons/arrow_up_down_icon';
 import { LoadingWrapper } from '../common/loading';
@@ -20,6 +26,7 @@ interface StateProps {
     ethInUsd: BigNumber | null;
     web3State: Web3State;
     wethBalance: BigNumber;
+    convertBalanceState: ConvertBalanceState;
 }
 
 interface DispatchProps {
@@ -155,7 +162,16 @@ class WalletWethBalance extends React.PureComponent<Props, State> {
     };
 
     public render = () => {
-        const { ethBalance, web3State, wethBalance, ethInUsd, theme, inDropdown, className } = this.props;
+        const {
+            ethBalance,
+            web3State,
+            wethBalance,
+            ethInUsd,
+            theme,
+            inDropdown,
+            className,
+            convertBalanceState,
+        } = this.props;
         const { isSubmitting } = this.state;
         const totalEth = ethBalance.plus(wethBalance);
         const formattedEth = tokenAmountInUnits(ethBalance, 18);
@@ -163,6 +179,8 @@ class WalletWethBalance extends React.PureComponent<Props, State> {
         const formattedTotalEth = tokenAmountInUnits(totalEth, 18);
 
         let content: React.ReactNode;
+
+        const isButtonConvertDisable = convertBalanceState !== ConvertBalanceState.Success;
 
         if (web3State === Web3State.Loading) {
             content = <LoadingWrapper />;
@@ -173,7 +191,7 @@ class WalletWethBalance extends React.PureComponent<Props, State> {
                         <Label>ETH</Label>
                         <Value>{formattedEth}</Value>
                     </Row>
-                    <Button onClick={this.openModal}>
+                    <Button disabled={isButtonConvertDisable} onClick={this.openModal}>
                         <ButtonLabel>Convert</ButtonLabel>
                         <ArrowUpDownIcon />
                     </Button>
@@ -263,6 +281,7 @@ const mapStateToProps = (state: StoreState): StateProps => {
         wethBalance: getWethBalance(state),
         web3State: getWeb3State(state),
         ethInUsd: getEthInUsd(state),
+        convertBalanceState: getConvertBalanceState(state),
     };
 };
 

--- a/src/store/blockchain/reducers.ts
+++ b/src/store/blockchain/reducers.ts
@@ -2,7 +2,7 @@ import { BigNumber } from '0x.js';
 import { getType } from 'typesafe-actions';
 
 import { DEFAULT_ESTIMATED_TRANSACTION_TIME_MS, DEFAULT_GAS_PRICE } from '../../common/constants';
-import { BlockchainState, Web3State } from '../../util/types';
+import { BlockchainState, ConvertBalanceState, Web3State } from '../../util/types';
 import * as actions from '../actions';
 import { RootAction } from '../reducers';
 
@@ -16,6 +16,7 @@ const initialBlockchainState: BlockchainState = {
         gasPriceInWei: DEFAULT_GAS_PRICE,
         estimatedTimeMs: DEFAULT_ESTIMATED_TRANSACTION_TIME_MS,
     },
+    convertBalanceState: ConvertBalanceState.Success,
 };
 
 export function blockchain(state: BlockchainState = initialBlockchainState, action: RootAction): BlockchainState {
@@ -42,6 +43,12 @@ export function blockchain(state: BlockchainState = initialBlockchainState, acti
             };
         case getType(actions.setEthBalance):
             return { ...state, ethBalance: action.payload };
+        case getType(actions.convertBalanceStateAsync.request):
+            return { ...state, convertBalanceState: ConvertBalanceState.Request };
+        case getType(actions.convertBalanceStateAsync.failure):
+            return { ...state, convertBalanceState: ConvertBalanceState.Failure };
+        case getType(actions.convertBalanceStateAsync.success):
+            return { ...state, convertBalanceState: ConvertBalanceState.Success };
         case getType(actions.initializeBlockchainData):
             return {
                 ...state,

--- a/src/store/selectors.ts
+++ b/src/store/selectors.ts
@@ -21,6 +21,7 @@ export const getTokenBalances = (state: StoreState) => state.blockchain.tokenBal
 export const getWeb3State = (state: StoreState) => state.blockchain.web3State;
 export const getEthBalance = (state: StoreState) => state.blockchain.ethBalance;
 export const getWethTokenBalance = (state: StoreState) => state.blockchain.wethTokenBalance;
+export const getConvertBalanceState = (state: StoreState) => state.blockchain.convertBalanceState;
 export const getWethBalance = (state: StoreState) =>
     state.blockchain.wethTokenBalance ? state.blockchain.wethTokenBalance.balance : new BigNumber(0);
 export const getOrders = (state: StoreState) => state.relayer.orders;

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -54,6 +54,7 @@ export interface BlockchainState {
     readonly ethBalance: BigNumber;
     readonly wethTokenBalance: TokenBalance | null;
     readonly gasInfo: GasInfo;
+    readonly convertBalanceState: ConvertBalanceState;
 }
 
 export interface RelayerState {
@@ -289,6 +290,12 @@ export interface Collectible {
 }
 
 export enum AllCollectiblesFetchStatus {
+    Request = 'Request',
+    Success = 'Success',
+}
+
+export enum ConvertBalanceState {
+    Failure = 'Failure',
     Request = 'Request',
     Success = 'Success',
 }


### PR DESCRIPTION
Connects #503 

### Includes
- Disable convert button when transaction is running
- Add support to the store to communicate the status of the transaction
- This is a video reproducing the problem 
https://www.loom.com/share/2eeb72a0eea349f89c03604f83d43cbd

