### PR TITLE
Add '/' to Etherscan link for Rinkeby

### DIFF
--- a/src/util/transaction_link.ts
+++ b/src/util/transaction_link.ts
@@ -3,7 +3,7 @@ import { Network } from '../util/types';
 
 const ETHERSCAN_TRANSACTION_URL: { [key: number]: string } = {
     [Network.Mainnet]: 'https://etherscan.io/tx/',
-    [Network.Rinkeby]: 'https://rinkeby.etherscan.io/tx',
+    [Network.Rinkeby]: 'https://rinkeby.etherscan.io/tx/',
     [Network.Kovan]: 'https://kovan.etherscan.io/tx/',
     [Network.Ganache]: 'https://etherscan.io/tx/',
 };


### PR DESCRIPTION
Apparently, there's a missing slash on Etherscan link on Rinkeby network, which leads to invalid links in the notification block.