### PR TITLE
Websocket

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -7,6 +7,7 @@ export const ERC721_APP_BASE_PATH = '/erc721';
 export const DEFAULT_BASE_PATH = process.env.REACT_APP_DEFAULT_BASE_PATH || ERC20_APP_BASE_PATH;
 
 export const RELAYER_URL = process.env.REACT_APP_RELAYER_URL || 'http://localhost:3001/api/v2';
+export const RELAYER_WEBSOCKET_URL = process.env.REACT_APP_RELAYER_WEBSOCKET_URL;
 
 export const TX_DEFAULTS = {
     gasLimit: 1000000,

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -77,6 +77,7 @@ export const STEP_MODAL_DONE_STATUS_VISIBILITY_TIME: number =
     Number.parseInt(process.env.REACT_APP_STEP_MODAL_DONE_STATUS_VISIBILITY_TIME as string, 10) || 3500;
 
 export const OPENSEA_API_KEY = process.env.REACT_APP_OPENSEA_API_KEY;
+export const OPENSEA_URL = process.env.REACT_APP_OPENSEA_URL;
 
 export const NETWORK_ID: number = Number.parseInt(process.env.REACT_APP_NETWORK_ID as string, 10) || Network.Mainnet;
 

--- a/src/services/collectibles_metadata_sources/opensea.ts
+++ b/src/services/collectibles_metadata_sources/opensea.ts
@@ -1,14 +1,14 @@
 import { RateLimit } from 'async-sema';
 
-import { COLLECTIBLE_ADDRESS, NETWORK_ID, OPENSEA_API_KEY } from '../../common/constants';
+import { COLLECTIBLE_ADDRESS, NETWORK_ID, OPENSEA_API_KEY, OPENSEA_URL } from '../../common/constants';
 import { Collectible, CollectibleMetadataSource } from '../../util/types';
 
 export class Opensea implements CollectibleMetadataSource {
     private readonly _rateLimit: () => Promise<void>;
 
     private readonly _endpointsUrls: { [key: number]: string } = {
-        1: 'https://api.opensea.io/api/v1',
-        4: 'https://rinkeby-api.opensea.io/api/v1',
+        1: OPENSEA_URL ? OPENSEA_URL : 'https://api.opensea.io/api/v1',
+        4: OPENSEA_URL ? OPENSEA_URL : 'https://rinkeby-api.opensea.io/api/v1',
     };
 
     public static getAssetsAsCollectible(assets: any[]): Collectible[] {

--- a/src/services/relayer.ts
+++ b/src/services/relayer.ts
@@ -1,27 +1,65 @@
 import { assetDataUtils, AssetProxyId, BigNumber } from '0x.js';
-import { HttpClient, OrderConfigRequest, OrderConfigResponse, SignedOrder } from '@0x/connect';
+import {
+    APIOrder,
+    HttpClient,
+    OrderConfigRequest,
+    OrderConfigResponse,
+    OrdersChannel,
+    ordersChannelFactory,
+    OrdersChannelHandler,
+    SignedOrder,
+} from '@0x/connect';
+import { orderHashUtils } from '@0x/order-utils';
 import { RateLimit } from 'async-sema';
 
-import { RELAYER_URL } from '../common/constants';
+import { RELAYER_URL, RELAYER_WEBSOCKET_URL } from '../common/constants';
+import { getLogger } from '../util/logger';
 import { tokenAmountInUnitsToBigNumber } from '../util/tokens';
 import { Token } from '../util/types';
+
+const logger = getLogger('relayer');
 
 export class Relayer {
     private readonly _client: HttpClient;
     private readonly _rateLimit: () => Promise<void>;
-
-    constructor(client: HttpClient, options: { rps: number }) {
-        this._client = client;
-        this._rateLimit = RateLimit(options.rps); // requests per second
+    private readonly _orders: Map<string, Set<SignedOrder>> = new Map();
+    private readonly _subscriptions: Map<string, boolean> = new Map();
+    private readonly _websocketUrl?: string;
+    private _ordersChannel?: OrdersChannel;
+    private static _key(baseTokenAssetData: string, quoteAssetData: string): string {
+        const assetDataKey = [baseTokenAssetData, quoteAssetData].sort().join('-');
+        return assetDataKey;
+    }
+    private static _getOrderHash(order: APIOrder | SignedOrder): string {
+        if ((order as APIOrder).metaData) {
+            const apiOrder = order as APIOrder;
+            const orderHash = (apiOrder.metaData as any).orderHash || orderHashUtils.getOrderHashHex(apiOrder.order);
+            return orderHash;
+        } else {
+            const orderHash = orderHashUtils.getOrderHashHex(order as SignedOrder);
+            return orderHash;
+        }
     }
 
+    constructor(client: HttpClient, options: { rps: number; websocketUrl?: string }) {
+        this._client = client;
+        this._rateLimit = RateLimit(options.rps); // requests per second
+        this._websocketUrl = options.websocketUrl;
+        logger.debug(this._websocketUrl);
+    }
     public async getAllOrdersAsync(baseTokenAssetData: string, quoteTokenAssetData: string): Promise<SignedOrder[]> {
-        const [sellOrders, buyOrders] = await Promise.all([
-            this._getOrdersAsync(baseTokenAssetData, quoteTokenAssetData),
-            this._getOrdersAsync(quoteTokenAssetData, baseTokenAssetData),
-        ]);
-
-        return [...sellOrders, ...buyOrders];
+        const ordersKey = Relayer._key(baseTokenAssetData, quoteTokenAssetData);
+        if (!this._subscriptions.has(ordersKey)) {
+            // first time we have had this request
+            const [latestSellOrders, latestBuyOrders] = await Promise.all([
+                this._getOrdersAsync(baseTokenAssetData, quoteTokenAssetData),
+                this._getOrdersAsync(quoteTokenAssetData, baseTokenAssetData),
+            ]);
+            this._orders.set(ordersKey, new Set([...latestSellOrders, ...latestBuyOrders]));
+            await this._createSubscriptionIfRequiredAsync(baseTokenAssetData, quoteTokenAssetData);
+        }
+        const orders = this._orders.get(ordersKey) || new Set();
+        return Array.from(orders.values());
     }
 
     public async getOrderConfigAsync(orderConfig: OrderConfigRequest): Promise<OrderConfigResponse> {
@@ -34,25 +72,28 @@ export class Relayer {
         baseTokenAssetData: string,
         quoteTokenAssetData: string,
     ): Promise<SignedOrder[]> {
-        const [sellOrders, buyOrders] = await Promise.all([
-            this._getOrdersAsync(baseTokenAssetData, quoteTokenAssetData, account),
-            this._getOrdersAsync(quoteTokenAssetData, baseTokenAssetData, account),
-        ]);
-
-        return [...sellOrders, ...buyOrders];
+        const orders = await this.getAllOrdersAsync(baseTokenAssetData, quoteTokenAssetData);
+        const filteredOrders = orders.filter(o => o.makerAddress === account.toLowerCase());
+        return filteredOrders;
     }
 
     public async getCurrencyPairPriceAsync(baseToken: Token, quoteToken: Token): Promise<BigNumber | null> {
         await this._rateLimit();
-        const { asks } = await this._client.getOrderbookAsync({
-            baseAssetData: assetDataUtils.encodeERC20AssetData(baseToken.address),
-            quoteAssetData: assetDataUtils.encodeERC20AssetData(quoteToken.address),
-        });
+        const baseAssetData = assetDataUtils.encodeERC20AssetData(baseToken.address);
+        const quoteAssetData = assetDataUtils.encodeERC20AssetData(quoteToken.address);
+        const allOrders = await this.getAllOrdersAsync(baseAssetData, quoteAssetData);
+        const asks = allOrders
+            .filter(o => {
+                return o.makerAssetData === baseAssetData && o.takerAssetData === quoteAssetData;
+            })
+            .sort((a, b) =>
+                a.makerAssetAmount.div(a.takerAssetAmount).comparedTo(b.makerAssetAmount.div(b.takerAssetAmount)),
+            );
 
-        if (asks.records.length) {
-            const lowestPriceAsk = asks.records[0];
+        if (asks.length) {
+            const lowestPriceAsk = asks[0];
 
-            const { makerAssetAmount, takerAssetAmount } = lowestPriceAsk.order;
+            const { makerAssetAmount, takerAssetAmount } = lowestPriceAsk;
             const takerAssetAmountInUnits = tokenAmountInUnitsToBigNumber(takerAssetAmount, quoteToken.decimals);
             const makerAssetAmountInUnits = tokenAmountInUnitsToBigNumber(makerAssetAmount, baseToken.decimals);
             return takerAssetAmountInUnits.div(makerAssetAmountInUnits);
@@ -114,13 +155,74 @@ export class Relayer {
         }
         return recordsToReturn;
     }
+    private _ordersReceived(orders: APIOrder[]): void {
+        // TODO make this more effecient
+        // create a list of orders to add or remove and remove/add them all at once
+        for (const order of orders) {
+            const orderKey = Relayer._key(order.order.makerAssetData, order.order.takerAssetData);
+            const remainingFillableTakerAssetAmount = (order.metaData as any).remainingFillableTakerAssetAmount;
+            const orderHash = Relayer._getOrderHash(order.order);
+            if (!this._orders.has(orderKey)) {
+                this._orders.set(orderKey, new Set());
+            }
+            const storedOrders = this._orders.get(orderKey) as Set<SignedOrder>;
+            // If we have the meta data informing us that the order cannot be filled for any amount we don't add it
+            if (remainingFillableTakerAssetAmount && new BigNumber(remainingFillableTakerAssetAmount).eq(0)) {
+                storedOrders.forEach(o => {
+                    if (orderHash === Relayer._getOrderHash(o)) {
+                        storedOrders.delete(o);
+                    }
+                });
+            } else {
+                storedOrders.add(order.order);
+            }
+        }
+    }
+    private async _createSubscriptionIfRequiredAsync(
+        baseTokenAssetData: string,
+        quoteTokenAssetData: string,
+    ): Promise<void> {
+        if (!this._websocketUrl) {
+            return;
+        }
+        if (!this._ordersChannel) {
+            this._ordersChannel = await this._createOrdersChannelAsync();
+        }
+        const ordersKey = Relayer._key(baseTokenAssetData, quoteTokenAssetData);
+        if (!this._subscriptions.has(ordersKey)) {
+            this._ordersChannel.subscribe({
+                baseAssetData: baseTokenAssetData,
+                quoteAssetData: quoteTokenAssetData,
+                limit: 100,
+            });
+            // No need for a second subscription as this contains updates on both pairs
+            this._subscriptions.set(ordersKey, true);
+        }
+    }
+    private async _createOrdersChannelAsync(): Promise<OrdersChannel> {
+        if (!this._websocketUrl) {
+            throw new Error('Cannot create OrdersChannel without Websocket URL');
+        }
+        const ordersChannelHandler: OrdersChannelHandler = {
+            onUpdate: async (_channel, _opts, apiOrders) => {
+                this._ordersReceived(apiOrders);
+            },
+            // tslint:disable-next-line:no-empty
+            onError: (_channel, err) => {},
+            onClose: async () => {
+                this._ordersChannel = undefined;
+                this._subscriptions.clear();
+            },
+        };
+        return ordersChannelFactory.createWebSocketOrdersChannelAsync(this._websocketUrl, ordersChannelHandler);
+    }
 }
 
 let relayer: Relayer;
 export const getRelayer = (): Relayer => {
     if (!relayer) {
         const client = new HttpClient(RELAYER_URL);
-        relayer = new Relayer(client, { rps: 5 });
+        relayer = new Relayer(client, { rps: 5, websocketUrl: RELAYER_WEBSOCKET_URL });
     }
 
     return relayer;

--- a/src/util/ui_orders.ts
+++ b/src/util/ui_orders.ts
@@ -60,7 +60,7 @@ const ordersToUIOrdersWithoutOrderInfo = (orders: SignedOrder[], baseToken: Toke
 const filterUIOrders = (orders: UIOrder[]): UIOrder[] => {
     // For Market Fill we remove ANY orders which cannot be filled for their remaining amount.
     const marketFillFilter = (o: UIOrder) =>
-        o.makerFillableAmountInTakerAsset.isGreaterThan(o.remainingTakerAssetFillAmount);
+        o.makerFillableAmountInTakerAsset.isGreaterThanOrEqualTo(o.remainingTakerAssetFillAmount);
     const filteredOrders = orders.filter(marketFillFilter);
     logger.info(`filtered ${orders.length - filteredOrders.length}/${orders.length} orders`);
     return filteredOrders;


### PR DESCRIPTION
With backend supporting websocket the front end can now subscribe. This allows for faster orderbook updates as polling overhead is reduced. 

0xProject/0x-launch-kit-backend#71

Running over 15 minutes we see a large difference in number of requests and bandwidth consumed.

| change    | before | after |
| --------- | ------ | ----- |
| bandwidth | 12mb   | 288kb |
| requests  | 2462   | 431   |

<img width="1395" alt="Screen Shot 2019-07-30 at 10 18 14 pm" src="https://user-images.githubusercontent.com/27389/62128692-459cc600-b318-11e9-8349-d56e23f5851c.png">
