### PR TITLE
Use kovan network id in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ A browser tab will open in the `http://localhost:3001` address. You'll need to c
 You can optionally pass in any relayer endpoint that complies with the [0x Standard Relayer API](https://github.com/0xProject/standard-relayer-api). For example, if you want to mirror Kovan liquidity from [Radar Relay](https://radarrelay.com/):
 
 ```
-REACT_APP_RELAYER_URL='https://api.kovan.radarrelay.com/0x/v2' yarn start
+REACT_APP_RELAYER_URL='https://api.kovan.radarrelay.com/0x/v2' REACT_APP_NETWORK_ID=42 yarn start
 ```
 
 These commands start the app in development mode. You can run `yarn build` to build the assets. The results will be in the `build` directory. Remember to set the environment variable with the relayer URL when running the `build` command:


### PR DESCRIPTION
To make sure the command works to use with Radar's kovan API endpoint, set the network id to Kovan as well.