### PR TITLE
Filter orders by custom maker addresses

### DIFF
--- a/src/store/market/reducers.ts
+++ b/src/store/market/reducers.ts
@@ -6,6 +6,15 @@ import { MarketState } from '../../util/types';
 import * as actions from '../actions';
 import { RootAction } from '../reducers';
 
+const getMakerAddresses = () => {
+    const makerAddressesString = queryString.parse(queryString.extract(window.location.hash)).makerAddresses as string;
+    if (!makerAddressesString) {
+        return null;
+    }
+    const makerAddresses = makerAddressesString.split(',');
+    return makerAddresses.map(a => a.toLowerCase());
+};
+
 const initialMarketState: MarketState = {
     currencyPair: {
         base: (queryString.parse(queryString.extract(window.location.hash)).base as string) || availableMarkets[0].base,
@@ -16,6 +25,7 @@ const initialMarketState: MarketState = {
     quoteToken: null,
     markets: null,
     ethInUsd: null,
+    makerAddresses: getMakerAddresses(),
 };
 
 export function market(state: MarketState = initialMarketState, action: RootAction): MarketState {

--- a/src/store/relayer/actions.ts
+++ b/src/store/relayer/actions.ts
@@ -24,6 +24,7 @@ import {
     getEthAccount,
     getEthBalance,
     getGasPriceInWei,
+    getMakerAddresses,
     getOpenBuyOrders,
     getOpenSellOrders,
     getQuoteToken,
@@ -51,14 +52,15 @@ export const getAllOrders: ThunkCreator = () => {
         const baseToken = getBaseToken(state) as Token;
         const quoteToken = getQuoteToken(state) as Token;
         const web3State = getWeb3State(state) as Web3State;
+        const makerAddresses = getMakerAddresses(state);
         try {
             let uiOrders: UIOrder[] = [];
             const isWeb3NotDoneState = [Web3State.Locked, Web3State.NotInstalled, Web3State.Error].includes(web3State);
             // tslint:disable-next-line:prefer-conditional-expression
             if (isWeb3NotDoneState) {
-                uiOrders = await getAllOrdersAsUIOrdersWithoutOrdersInfo(baseToken, quoteToken);
+                uiOrders = await getAllOrdersAsUIOrdersWithoutOrdersInfo(baseToken, quoteToken, makerAddresses);
             } else {
-                uiOrders = await getAllOrdersAsUIOrders(baseToken, quoteToken);
+                uiOrders = await getAllOrdersAsUIOrders(baseToken, quoteToken, makerAddresses);
             }
             dispatch(setOrders(uiOrders));
         } catch (err) {

--- a/src/store/selectors.ts
+++ b/src/store/selectors.ts
@@ -33,6 +33,7 @@ export const getStepsModalPendingSteps = (state: StoreState) => state.ui.stepsMo
 export const getStepsModalDoneSteps = (state: StoreState) => state.ui.stepsModal.doneSteps;
 export const getStepsModalCurrentStep = (state: StoreState) => state.ui.stepsModal.currentStep;
 export const getCurrencyPair = (state: StoreState) => state.market.currencyPair;
+export const getMakerAddresses = (state: StoreState) => state.market.makerAddresses;
 export const getBaseToken = (state: StoreState) => state.market.baseToken;
 export const getQuoteToken = (state: StoreState) => state.market.quoteToken;
 export const getMarkets = (state: StoreState) => state.market.markets;

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -79,6 +79,7 @@ export interface MarketState {
     readonly quoteToken: Token | null;
     readonly ethInUsd: BigNumber | null;
     readonly markets: Market[] | null;
+    readonly makerAddresses: string[] | null;
 }
 
 export interface StoreState {


### PR DESCRIPTION
This feature adds the ability for the front-end to be filtered by a set of specified maker addresses. This filtering can be achieved by specifying a comma-separated list of ethereum addresses in the url via the `makerAddresses` query param.

To test:
- Copy `.env.example` into `.env`
- Update `REACT_APP_RELAYER_URL='https://api.radarrelay.com/0x/v2'`
- Update `REACT_APP_NETWORK_ID=1`
- Go to http://localhost:3001/#/erc20/?base=mkr&quote=weth&makerAddresses=0x2733bc229e016b743a086a66d92ecded9bf0b0fe