### PR TITLE
Fix docker compose file in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,18 +66,17 @@ services:
         ports:
             - '3000:3000'
     mesh:
-        image: 0xorg/mesh:0xV3
+        image: 0xorg/mesh:7.2.1-beta-0xv3
         environment:
             ETHEREUM_RPC_URL: 'http://ganache:8545'
-            ETHEREUM_CHAIN_ID: '1337'
-            ETHEREUM_NETWORK_ID: '50'
-            USE_BOOTSTRAP_LIST: 'true'
+            ETHEREUM_CHAIN_ID: 1337
             VERBOSITY: 3
-            PRIVATE_KEY_PATH: ''
-            BLOCK_POLLING_INTERVAL: '5s'
-            P2P_LISTEN_PORT: '60557'
+            RPC_ADDR: 'mesh:60557'
         ports:
             - '60557:60557'
+            - '60558:60558'
+            - '60559:60559'
+
 ```
 
 and then run `docker-compose up`. This will create three containers: one has a ganache with the 0x contracts deployed and some test tokens, another one has an instance of the [launch kit](https://github.com/0xProject/0x-launch-kit) implementation of a relayer that connects to that ganache and finally a container for [0x-mesh](https://github.com/0xProject/0x-mesh) for order sharing and discovery on a p2p network.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ REACT_APP_RELAYER_URL='https://RELAYER_URL/' REACT_APP_RELAYER_WS_URL='wss://REL
 
 A browser tab will open in the `http://localhost:3001` address. You'll need to connect MetaMask to the network used by the relayer.
 
-You can optionally pass in any relayer endpoint that complies with the [0x Standard Relayer API](https://github.com/0xProject/standard-relayer-api). For example, if you want to mirror Kovan liquidity from [Radar Relay](https://radarrelay.com/):
+You can optionally pass in any relayer endpoint that complies with the [0x Standard Relayer API](https://github.com/0xProject/standard-relayer-api). For example, if you want to show liquidity from 0x API:
 
 ```
 REACT_APP_RELAYER_URL='https://api.0x.org/sra' REACT_APP_RELAYER_WS_URL='wss://api.0x.org/sra' REACT_APP_NETWORK_ID=1 REACT_APP_CHAIN_ID=1 yarn start

--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ services:
             ETHEREUM_CHAIN_ID: 1337
             VERBOSITY: 3
             RPC_ADDR: 'mesh:60557'
+            # You can decrease the BLOCK_POLLING_INTERVAL for test networks to
+            # improve performance. See https://0x-org.gitbook.io/mesh/ for more
+            # Documentation about Mesh and its environment variables.
+            BLOCK_POLLING_INTERVAL: '5s'
         ports:
             - '60557:60557'
             - '60558:60558'

--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ services:
             - '60557:60557'
             - '60558:60558'
             - '60559:60559'
-
 ```
 
 and then run `docker-compose up`. This will create three containers: one has a ganache with the 0x contracts deployed and some test tokens, another one has an instance of the [launch kit](https://github.com/0xProject/0x-launch-kit) implementation of a relayer that connects to that ganache and finally a container for [0x-mesh](https://github.com/0xProject/0x-mesh) for order sharing and discovery on a p2p network.


### PR DESCRIPTION
There were a lot of problems with how Mesh is set up in the Docker Compose file in the README. This resulted in the backend not being able to connect and the following errors in the logs:

```
(node:18) UnhandledPromiseRejectionWarning: Error: Failed to establish under-the-hood heartbeat subscription
backend_1  |     at WSClient.<anonymous> (/usr/src/app/node_modules/@0x/mesh-rpc-client/lib/src/ws_client.js:519:31)
backend_1  |     at step (/usr/src/app/node_modules/@0x/mesh-rpc-client/lib/src/ws_client.js:43:23)
backend_1  |     at Object.throw (/usr/src/app/node_modules/@0x/mesh-rpc-client/lib/src/ws_client.js:24:53)
backend_1  |     at rejected (/usr/src/app/node_modules/@0x/mesh-rpc-client/lib/src/ws_client.js:16:65)
backend_1  |     at processTicksAndRejections (internal/process/task_queues.js:86:5)
backend_1  | (node:18) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
backend_1  | (node:18) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
backend_1  | (node:18) UnhandledPromiseRejectionWarning: Error: Failed to establish under-the-hood heartbeat subscription
backend_1  |     at WSClient.<anonymous> (/usr/src/app/node_modules/@0x/mesh-rpc-client/lib/src/ws_client.js:519:31)
backend_1  |     at step (/usr/src/app/node_modules/@0x/mesh-rpc-client/lib/src/ws_client.js:43:23)
backend_1  |     at Object.throw (/usr/src/app/node_modules/@0x/mesh-rpc-client/lib/src/ws_client.js:24:53)
backend_1  |     at rejected (/usr/src/app/node_modules/@0x/mesh-rpc-client/lib/src/ws_client.js:16:65)
backend_1  |     at processTicksAndRejections (internal/process/task_queues.js:86:5)
```

This PR updates the docker compose file so that it works correctly and the backend is able to connect to Mesh.