### PR TITLE
Fix alignment of images for collectible list

### DIFF
--- a/src/components/erc721/collectibles/collectible_details_item_list.tsx
+++ b/src/components/erc721/collectibles/collectible_details_item_list.tsx
@@ -43,6 +43,7 @@ const TextContainer = styled.div`
     display: flex;
     flex-grow: 1;
     padding: 0 10px 0 0;
+    overflow: hidden;
 `;
 
 const Title = styled.h3`


### PR DESCRIPTION
Before:

![Screen Shot 2019-12-05 at 11 42 46 PM](https://user-images.githubusercontent.com/800857/70305464-4e674200-17b9-11ea-802d-9219372eac03.png)


After:

![Screen Shot 2019-12-05 at 11 42 56 PM](https://user-images.githubusercontent.com/800857/70305467-54f5b980-17b9-11ea-9bae-088f2661c4f0.png)
